### PR TITLE
Static initialization & Syntax changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ There are languages such as `Rust` which succeed in making this gap smaller, but
 ```rust
 let main = fn {
 	println("Hello World");
-}
+};
 ```
 
 ## Installation
@@ -215,19 +215,22 @@ pub let im_public = 5;
 
 // you can use other modules (files) using the `import` keyword
 // foo is on the same directory as us, so we only have to type `foo`.
-let foo = import("foo")
+let foo = import("foo");
 
 // modules can be unpacked the same way as structs
-let { im_public } = import("foo")
+let { im_public } = import("foo");
+
+// the previous two import can be combined into one
+let foo @ { im_public } = import("foo");
 
 // the compiler can automatically unpack all public
 // symbols from `foo` for us, using `?`
-let ? = import("foo")
+let ? = import("foo");
 
 // Using the imported symbol
 let main = fn() {
     let x = im_public; // we can now use im_public in `bar.chl`
-}
+};
 ```
 
 ## Licenses

--- a/editors/vscode/syntaxes/chili.tmLanguage.json
+++ b/editors/vscode/syntaxes/chili.tmLanguage.json
@@ -64,7 +64,7 @@
         },
         {
           "name": "keyword.other.chili",
-          "match": "\\b(let|fn|import|extern|intrinsic|use|mod|as|struct|union)\\b"
+          "match": "\\b(let|fn|import|extern|intrinsic|static|use|mod|as|struct|union)\\b"
         },
         {
           "name": "storage.modifier.chili",
@@ -154,6 +154,24 @@
               "name": "keyword.other.chili"
             },
             "3": {
+              "name": "keyword.other.chili"
+            },
+            "4": {
+              "name": "entity.name.function.chili"
+            }
+          },
+          "match": "\\b(pub\\s*)?(let)\\s*(mut\\s*)?([[:alpha:]_][[:alnum:]_]*)\\b"
+        },
+        {
+          "comment": "extern let binding",
+          "captures": {
+            "1": {
+              "name": "storage.modifier.chili"
+            },
+            "2": {
+              "name": "keyword.other.chili"
+            },
+            "3": {
               "name": "string.quoted.double.chili"
             },
             "4": {
@@ -163,13 +181,55 @@
               "name": "keyword.other.chili"
             },
             "6": {
-              "name": "storage.modifier.chili"
-            },
-            "7": {
               "name": "entity.name.function.chili"
             }
           },
-          "match": "\\b(pub\\s*)?(\\b(extern|intrinsic)\\b\\s*(\".+\"\\s*)?)?(let\\s*)(mut\\s*)?([[:alpha:]_][[:alnum:]_]*)\\b"
+          "match": "\\b(pub\\s*)?\\b(extern)\\b\\s*(\".+\"\\s*)?(let)\\s*(mut\\s*)?([[:alpha:]_][[:alnum:]_]*)\\b"
+        },
+        {
+          "comment": "static let binding",
+          "captures": {
+            "1": {
+              "name": "storage.modifier.chili"
+            },
+            "2": {
+              "name": "keyword.other.chili"
+            },
+            "3": {
+              "name": "keyword.other.chili"
+            },
+            "4": {
+              "name": "keyword.other.chili"
+            },
+            "5": {
+              "name": "keyword.other.chili"
+            },
+            "6": {
+              "name": "entity.name.function.chili"
+            }
+          },
+          "match": "\\b(pub\\s*)?(\\b(static)\\b)\\s*(let)\\s*(mut\\s*)?([[:alpha:]_][[:alnum:]_]*)\\b"
+        },
+        {
+          "comment": "intrinsic let binding",
+          "captures": {
+            "1": {
+              "name": "storage.modifier.chili"
+            },
+            "2": {
+              "name": "keyword.other.chili"
+            },
+            "3": {
+              "name": "keyword.other.chili"
+            },
+            "4": {
+              "name": "keyword.other.chili"
+            },
+            "5": {
+              "name": "entity.name.function.chili"
+            }
+          },
+          "match": "\\b(pub\\s*)?(\\b(intrinsic)\\b)\\s*(let)\\s*([[:alpha:]_][[:alnum:]_]*)\\b"
         },
         {
           "name": "support.function.builtin.chili",

--- a/editors/vscode/syntaxes/chili.tmLanguage.json
+++ b/editors/vscode/syntaxes/chili.tmLanguage.json
@@ -154,13 +154,13 @@
               "name": "keyword.other.chili"
             },
             "3": {
-              "name": "keyword.other.chili"
+              "name": "string.quoted.double.chili"
             },
             "4": {
               "name": "keyword.other.chili"
             },
             "5": {
-              "name": "string.quoted.double.chili"
+              "name": "keyword.other.chili"
             },
             "6": {
               "name": "storage.modifier.chili"
@@ -169,7 +169,7 @@
               "name": "entity.name.function.chili"
             }
           },
-          "match": "\\b(pub\\s*)?(let\\s*)(\\b(extern|intrinsic)\\b\\s*(\".+\"\\s*)?)?(mut\\s*)?([[:alpha:]_][[:alnum:]_]*)\\b"
+          "match": "\\b(pub\\s*)?(\\b(extern|intrinsic)\\b\\s*(\".+\"\\s*)?)?(let\\s*)(mut\\s*)?([[:alpha:]_][[:alnum:]_]*)\\b"
         },
         {
           "name": "support.function.builtin.chili",

--- a/examples/playground/build.chl
+++ b/examples/playground/build.chl
@@ -1,4 +1,4 @@
-let ? = import("std/build")
+let ? = import("std/build");
 
 let build = fn() {
 	let build_options = BuildOptions {
@@ -18,6 +18,6 @@ let build = fn() {
 	if ok {
 		run_output_file(output_file);
 	}
-}
+};
 
-run!(build())
+run!(build());

--- a/examples/playground/src/main.chl
+++ b/examples/playground/src/main.chl
@@ -1,6 +1,6 @@
 let ? = import("std/c");
 
-static let mut answer = 42;
+static let answer = 42;
 
 let main = fn {
     printf("answer = %d\n".data, answer);

--- a/examples/playground/src/main.chl
+++ b/examples/playground/src/main.chl
@@ -1,3 +1,8 @@
+let ? = import("std/c");
+
+static let mut answer = 42;
+
 let main = fn {
+    printf("answer = %d\n".data, answer);
     println("Hello World");
 };

--- a/examples/playground/src/main.chl
+++ b/examples/playground/src/main.chl
@@ -1,3 +1,3 @@
 let main = fn {
     println("Hello World");
-}
+};

--- a/examples/playground/src/main.chl
+++ b/examples/playground/src/main.chl
@@ -1,8 +1,9 @@
 let ? = import("std/c");
 
-static let answer = 42;
+let get_a = fn { 42 };
 
 let main = fn {
+    static let answer = get_a();
     printf("answer = %d\n".data, answer);
     println("Hello World");
 };

--- a/lib/std/build.chl
+++ b/lib/std/build.chl
@@ -1,5 +1,5 @@
 pub let { start_workspace } = import("std/intrinsics");
-let { execl } = import("std/c")
+let { execl } = import("std/c");
 
 pub let Workspace = struct {
     name: str,
@@ -26,4 +26,4 @@ pub let OptimizationLevel_release: OptimizationLevel = 1;
 
 pub let run_output_file = fn(output_file: str) {
     execl(output_file.data, 0);
-}
+};

--- a/lib/std/c.chl
+++ b/lib/std/c.chl
@@ -1,8 +1,8 @@
 pub let extern "c" putchar = fn(char: int) -> int;
 pub let extern "c" getchar = fn() -> int;
 
-pub let extern "c" printf = fn(input: *u8, ..args) -> int;
-pub let extern "c" sprintf_s = fn(buffer: *u8, sizeOfBuffer: uint, format: *u8, ..args) -> int;
+pub let extern "c" printf = fn(input: *u8, args...) -> int;
+pub let extern "c" sprintf_s = fn(buffer: *u8, sizeOfBuffer: uint, format: *u8, args...) -> int;
 
 pub let extern "c" strcpy = fn(dest: *u8, src: *u8) -> *u8;
 
@@ -28,7 +28,7 @@ pub let extern "c" srand = fn(seed: uint);
 pub let extern "c" rand = fn() -> uint;
 pub let extern "c" time = fn(some: *i8) -> uint;
 
-pub let extern "c" execl = fn(path: *u8, ..args) -> int;
+pub let extern "c" execl = fn(path: *u8, args...) -> int;
 
 pub let extern "c" abort = fn() -> never;
 pub let extern "c" exit = fn(status: int) -> never;

--- a/lib/std/c.chl
+++ b/lib/std/c.chl
@@ -1,34 +1,34 @@
-pub let extern "c" putchar = fn(char: int) -> int;
-pub let extern "c" getchar = fn() -> int;
+pub extern "c" let putchar = fn(char: int) -> int;
+pub extern "c" let getchar = fn() -> int;
 
-pub let extern "c" printf = fn(input: *u8, args...) -> int;
-pub let extern "c" sprintf_s = fn(buffer: *u8, sizeOfBuffer: uint, format: *u8, args...) -> int;
+pub extern "c" let printf = fn(input: *u8, args...) -> int;
+pub extern "c" let sprintf_s = fn(buffer: *u8, sizeOfBuffer: uint, format: *u8, args...) -> int;
 
-pub let extern "c" strcpy = fn(dest: *u8, src: *u8) -> *u8;
+pub extern "c" let strcpy = fn(dest: *u8, src: *u8) -> *u8;
 
-pub let extern "c" malloc = fn(size: uint) -> *i8;
-pub let extern "c" calloc = fn(nitems: uint, size: uint) -> *i8;
-pub let extern "c" realloc = fn(ptr: *i8, size: uint) -> *i8;
-pub let extern "c" free = fn(memblock: *i8);
+pub extern "c" let malloc = fn(size: uint) -> *i8;
+pub extern "c" let calloc = fn(nitems: uint, size: uint) -> *i8;
+pub extern "c" let realloc = fn(ptr: *i8, size: uint) -> *i8;
+pub extern "c" let free = fn(memblock: *i8);
 
-pub let extern "c" abs = fn(x: i32) -> i32;
+pub extern "c" let abs = fn(x: i32) -> i32;
 
-pub let extern "c" sinf = fn(arg: f32) -> f32;
-pub let extern "c" sin = fn(arg: f64) -> f64;
+pub extern "c" let sinf = fn(arg: f32) -> f32;
+pub extern "c" let sin = fn(arg: f64) -> f64;
 
-pub let extern "c" cosf = fn(arg: f32) -> f32;
-pub let extern "c" cos = fn(arg: f64) -> f64;
+pub extern "c" let cosf = fn(arg: f32) -> f32;
+pub extern "c" let cos = fn(arg: f64) -> f64;
 
-pub let extern "c" atan2f = fn(y: f32, x: f32) -> f32;
-pub let extern "c" atan2 = fn(y: f64, x: f64) -> f64;
+pub extern "c" let atan2f = fn(y: f32, x: f32) -> f32;
+pub extern "c" let atan2 = fn(y: f64, x: f64) -> f64;
 
-pub let extern "c" pow = fn(x: f64, y: f64) -> f64;
+pub extern "c" let pow = fn(x: f64, y: f64) -> f64;
 
-pub let extern "c" srand = fn(seed: uint);
-pub let extern "c" rand = fn() -> uint;
-pub let extern "c" time = fn(some: *i8) -> uint;
+pub extern "c" let srand = fn(seed: uint);
+pub extern "c" let rand = fn() -> uint;
+pub extern "c" let time = fn(some: *i8) -> uint;
 
-pub let extern "c" execl = fn(path: *u8, args...) -> int;
+pub extern "c" let execl = fn(path: *u8, args...) -> int;
 
-pub let extern "c" abort = fn() -> never;
-pub let extern "c" exit = fn(status: int) -> never;
+pub extern "c" let abort = fn() -> never;
+pub extern "c" let exit = fn(status: int) -> never;

--- a/lib/std/intrinsics.chl
+++ b/lib/std/intrinsics.chl
@@ -1,4 +1,4 @@
 let { Workspace } = import("std/build");
 
 // Workspace
-pub intrinsic let start_workspace = fn(workspace: Workspace) -> (str, bool);
+pub intrinsic let start_workspace: fn(workspace: Workspace) -> (str, bool);

--- a/lib/std/intrinsics.chl
+++ b/lib/std/intrinsics.chl
@@ -1,4 +1,4 @@
 let { Workspace } = import("std/build");
 
 // Workspace
-pub let intrinsic start_workspace = fn(workspace: Workspace) -> (str, bool);
+pub intrinsic let start_workspace = fn(workspace: Workspace) -> (str, bool);

--- a/lib/std/intrinsics.chl
+++ b/lib/std/intrinsics.chl
@@ -1,4 +1,4 @@
 let { Workspace } = import("std/build");
 
 // Workspace
-pub intrinsic let start_workspace: fn(workspace: Workspace) -> (str, bool);
+pub intrinsic let start_workspace = fn(workspace: Workspace) -> (str, bool);

--- a/lib/std/panicking.chl
+++ b/lib/std/panicking.chl
@@ -8,7 +8,7 @@ let PanicInfo = struct {
 };
 
 let default_panic_handler = fn(info: PanicInfo) -> never {
-    // TODO: use my own print routine.
+    // TODO: use our own print routine.
     let message = if info.message.len == 0 {
         ""
     } else {

--- a/lib/std/std.chl
+++ b/lib/std/std.chl
@@ -4,4 +4,3 @@ pub let build = import("std/build");
 pub let c = import("std/c");
 pub let fmt @ { print, println } = import("std/fmt");
 pub let panicking = import("std/panicking");
-pub let process = import("std/process");

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -19,6 +19,8 @@ use std::{
 };
 use ustr::Ustr;
 
+use self::pattern::NamePattern;
+
 #[derive(Debug, Clone)]
 pub struct Module {
     pub id: ModuleId,
@@ -397,7 +399,7 @@ pub struct FunctionSig {
 
 #[derive(Debug, PartialEq, Clone)]
 pub struct FunctionVarargs {
-    pub name: Ustr,
+    pub name: NamePattern,
     pub type_expr: Option<Box<Ast>>,
     pub span: Span,
 }

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -498,7 +498,7 @@ pub enum BindingKind {
     ExternFunction {
         name: NameAndSpan,
         lib: Option<ExternLibrary>,
-        function_type: FunctionSig,
+        sig: FunctionSig,
     },
     ExternVariable {
         name: NameAndSpan,

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -494,6 +494,7 @@ pub enum BindingKind {
         pattern: Pattern,
         type_expr: Option<Box<Ast>>,
         value: Box<Ast>,
+        is_static: bool,
     },
     ExternFunction {
         name: NameAndSpan,

--- a/src/backend/llvm/codegen.rs
+++ b/src/backend/llvm/codegen.rs
@@ -84,6 +84,10 @@ pub(super) struct Generator<'g, 'ctx> {
     pub(super) extern_libraries: HashSet<ExternLibrary>,
 
     pub(super) intrinsics: HashMap<hir::Intrinsic, FunctionValue<'ctx>>,
+
+    // This is an Option since it is only initialized after
+    // creating the startup function's state
+    pub(super) startup_function_state: Option<FunctionState<'ctx>>,
 }
 
 #[derive(Clone)]
@@ -136,7 +140,6 @@ pub(super) struct LoopBlock<'ctx> {
 
 impl<'g, 'ctx> Generator<'g, 'ctx> {
     pub(super) fn start(&mut self) {
-        self.gen_top_level_binding(self.workspace.entry_point_function_id.unwrap());
         self.gen_entry_point_function();
     }
 
@@ -178,7 +181,7 @@ impl<'g, 'ctx> Generator<'g, 'ctx> {
         decl
     }
 
-    pub(super) fn add_global_uninit(
+    pub(super) fn add_global(
         &mut self,
         id: BindingId,
         ty: BasicTypeEnum<'ctx>,

--- a/src/backend/llvm/codegen_static.rs
+++ b/src/backend/llvm/codegen_static.rs
@@ -1,0 +1,23 @@
+use super::codegen::{Codegen, Generator};
+use crate::hir;
+use inkwell::values::GlobalValue;
+
+impl<'g, 'ctx> Generator<'g, 'ctx> {
+    pub(super) fn initialize_static(&mut self, global_value: GlobalValue<'ctx>, value: &hir::Node) {
+        let prev_block = self.builder.get_insert_block();
+
+        let mut state = self.startup_function_state.clone().unwrap();
+
+        match state.current_block.get_first_instruction() {
+            Some(inst) => self.builder.position_at(state.current_block, &inst),
+            None => self.builder.position_at_end(state.current_block),
+        }
+
+        let value = value.codegen(self, &mut state);
+        self.build_store(global_value.as_pointer_value(), value);
+
+        if let Some(prev_block) = prev_block {
+            self.builder.position_at_end(prev_block);
+        }
+    }
+}

--- a/src/backend/llvm/mod.rs
+++ b/src/backend/llvm/mod.rs
@@ -4,6 +4,7 @@ mod codegen_builtin;
 mod codegen_control;
 mod codegen_literal;
 mod codegen_node;
+mod codegen_static;
 mod conditional;
 mod function;
 mod intrinsics;
@@ -102,6 +103,7 @@ pub fn codegen<'w>(workspace: &Workspace, tcx: &TypeCtx, cache: &hir::Cache) -> 
         extern_variables: UstrMap::default(),
         extern_libraries: HashSet::default(),
         intrinsics: HashMap::default(),
+        startup_function_state: None,
     };
 
     time! { workspace.build_options.emit_times, "llvm", {

--- a/src/check/mod.rs
+++ b/src/check/mod.rs
@@ -733,9 +733,7 @@ impl Check for ast::FunctionSig {
 
             if ty.is_none() && !self.kind.is_extern() {
                 return Err(Diagnostic::error()
-                    .with_message(
-                        "varargs without type annotation are only valid in extern functions",
-                    )
+                    .with_message("variadic parameter must be typed")
                     .with_label(Label::primary(varargs.span, "missing a type annotation")));
             }
 

--- a/src/check/mod.rs
+++ b/src/check/mod.rs
@@ -750,7 +750,7 @@ impl Check for ast::FunctionSig {
             }
 
             Some(Box::new(FunctionTypeVarargs {
-                name: varargs.name,
+                name: varargs.name.name,
                 ty,
             }))
         } else {

--- a/src/check/mod.rs
+++ b/src/check/mod.rs
@@ -393,6 +393,7 @@ impl Check for ast::Binding {
                 pattern,
                 type_expr,
                 value,
+                is_static: _,
             } => {
                 let ty = check_optional_type_expr(type_expr, sess, env, pattern.span())?;
 

--- a/src/check/mod.rs
+++ b/src/check/mod.rs
@@ -393,7 +393,7 @@ impl Check for ast::Binding {
                 pattern,
                 type_expr,
                 value,
-                is_static: _,
+                is_static,
             } => {
                 let ty = check_optional_type_expr(type_expr, sess, env, pattern.span())?;
 
@@ -423,7 +423,8 @@ impl Check for ast::Binding {
                 // Global immutable bindings must resolve to a const value, unless it is:
                 // - of type `type` or `module`
                 // - an extern binding
-                if env.scope_level().is_global()
+                if !is_static
+                    && env.scope_level().is_global()
                     && !value_node.is_const()
                     && !is_type_or_module
                     && !pattern.iter().any(|p| p.is_mutable)

--- a/src/check/pattern.rs
+++ b/src/check/pattern.rs
@@ -107,6 +107,18 @@ impl<'s> CheckSess<'s> {
                         ));
                     }
                 } else {
+                    if is_mutable && !matches!(kind, BindingInfoKind::Static) {
+                        self.workspace.diagnostics.push(
+                            Diagnostic::error()
+                                .with_message(format!(
+                                    "top level let binding `{}` cannot be mutable",
+                                    name
+                                ))
+                                .with_label(Label::primary(span, "cannot be mutable"))
+                                .with_note("try prefix the binding with `static`"),
+                        );
+                    }
+
                     // insert the symbol into its module's global scope
                     self.insert_global_binding_id(module_id, name, id);
                 }

--- a/src/infer/normalize.rs
+++ b/src/infer/normalize.rs
@@ -119,6 +119,7 @@ impl NormalizeCtx {
                 return_type: Box::new(self.normalize_kind(tcx, &f.return_type)),
                 varargs: f.varargs.as_ref().map(|v| {
                     Box::new(FunctionTypeVarargs {
+                        name: v.name,
                         ty: v.ty.as_ref().map(|ty| self.normalize_kind(tcx, ty)),
                     })
                 }),

--- a/src/interp/interp.rs
+++ b/src/interp/interp.rs
@@ -61,7 +61,7 @@ impl Interp {
             diagnostics: vec![],
             env_stack: vec![],
             // labels: vec![],
-            evaluated_globals: vec![],
+            statically_initialized_globals: vec![],
             lowered_functions: HashSet::new(),
         }
     }
@@ -85,8 +85,8 @@ pub struct InterpSess<'i> {
 
     // pub labels: Vec<Label>,
 
-    // Globals that are going to be evaluated when the VM starts
-    pub evaluated_globals: Vec<CompiledCode>,
+    // Globals that are going to be statically initialized when the VM starts
+    pub statically_initialized_globals: Vec<CompiledCode>,
 
     // Functions currently lowered, cached to prevent infinite recursion in recursive functions
     pub lowered_functions: HashSet<hir::FunctionId>,
@@ -145,7 +145,7 @@ impl<'i> InterpSess<'i> {
     fn insert_init_instructions(&mut self, mut code: CompiledCode) -> CompiledCode {
         let mut init_instructions: Vec<Instruction> = vec![];
 
-        for (i, global_eval_code) in self.evaluated_globals.iter().enumerate() {
+        for (i, global_eval_code) in self.statically_initialized_globals.iter().enumerate() {
             let const_slot = self.interp.constants.len();
 
             let id = hir::FunctionId::from(usize::MAX - i);

--- a/src/parse/binding.rs
+++ b/src/parse/binding.rs
@@ -91,12 +91,12 @@ impl Parser {
             }
         } else if eat!(self, Eq) {
             require!(self, Fn, "fn")?;
-            let function_type = self.parse_function_sig(name, Some(lib.clone()))?;
+            let sig = self.parse_function_sig(name, Some(lib.clone()))?;
 
             ast::BindingKind::ExternFunction {
                 name: name_and_span,
                 lib,
-                function_type,
+                sig,
             }
         } else {
             return Err(SyntaxError::expected(self.previous_span(), ": or ="));
@@ -127,7 +127,7 @@ impl Parser {
                 .with_label(Label::primary(id.span, "unknown intrinsic"))
         })?;
 
-        require!(self, Eq, "=")?;
+        require!(self, Colon, ":")?;
         require!(self, Fn, "fn")?;
         let function_type = self.parse_function_sig(name, None)?;
 

--- a/src/parse/binding.rs
+++ b/src/parse/binding.rs
@@ -127,7 +127,7 @@ impl Parser {
                 .with_label(Label::primary(id.span, "unknown intrinsic"))
         })?;
 
-        require!(self, Colon, ":")?;
+        require!(self, Eq, "=")?;
         require!(self, Fn, "fn")?;
         let function_type = self.parse_function_sig(name, None)?;
 

--- a/src/parse/binding.rs
+++ b/src/parse/binding.rs
@@ -38,11 +38,12 @@ impl Parser {
         })
     }
 
-    pub fn parse_extern(
+    pub fn parse_extern_binding(
         &mut self,
         visibility: ast::Visibility,
-        start_span: Span,
     ) -> DiagnosticResult<ast::Binding> {
+        let start_span = self.previous_span();
+
         let lib = eat!(self, Str(_)).then(|| self.previous().name());
 
         let lib = if let Some(lib) = lib {
@@ -56,6 +57,8 @@ impl Parser {
         } else {
             None
         };
+
+        require!(self, Let, "let")?;
 
         let is_mutable = eat!(self, Mut);
 
@@ -107,11 +110,14 @@ impl Parser {
         })
     }
 
-    pub fn parse_builtin_binding(
+    pub fn parse_intrinsic_binding(
         &mut self,
         visibility: ast::Visibility,
-        start_span: Span,
     ) -> DiagnosticResult<ast::Binding> {
+        let start_span = self.previous_span();
+
+        require!(self, Let, "let")?;
+
         let id = require!(self, Ident(_), "an identifier")?;
         let name = id.name();
 

--- a/src/parse/expr.rs
+++ b/src/parse/expr.rs
@@ -55,14 +55,13 @@ impl Parser {
 
         let expr = if is_stmt {
             if eat!(self, Let) {
-                let start_span = self.previous_span();
-
-                let binding = if eat!(self, Extern) {
-                    self.parse_extern(Visibility::Private, start_span)?
-                } else {
-                    self.parse_binding(Visibility::Private)?
-                };
-
+                let binding = self.parse_binding(Visibility::Private)?;
+                Ok(Ast::Binding(binding))
+            } else if eat!(self, Extern) {
+                let binding = self.parse_extern_binding(Visibility::Private)?;
+                Ok(Ast::Binding(binding))
+            } else if eat!(self, Intrinsic) {
+                let binding = self.parse_intrinsic_binding(Visibility::Private)?;
                 Ok(Ast::Binding(binding))
             } else {
                 self.parse_logic_or()

--- a/src/parse/expr.rs
+++ b/src/parse/expr.rs
@@ -285,7 +285,7 @@ impl Parser {
             } else {
                 return Err(SyntaxError::expected(
                     self.span(),
-                    &format!("[ or {{, got `{}`", self.peek().lexeme),
+                    &format!("{{, got `{}`", self.peek().lexeme),
                 ));
             }
         } else if eat!(self, Break | Continue | Return) {

--- a/src/parse/expr.rs
+++ b/src/parse/expr.rs
@@ -54,17 +54,9 @@ impl Parser {
         self.decl_name_frames.push(decl_name);
 
         let expr = if is_stmt {
-            if eat!(self, Let) {
-                let binding = self.parse_binding(Visibility::Private)?;
-                Ok(Ast::Binding(binding))
-            } else if eat!(self, Extern) {
-                let binding = self.parse_extern_binding(Visibility::Private)?;
-                Ok(Ast::Binding(binding))
-            } else if eat!(self, Intrinsic) {
-                let binding = self.parse_intrinsic_binding(Visibility::Private)?;
-                Ok(Ast::Binding(binding))
-            } else {
-                self.parse_logic_or()
+            match self.try_parse_any_binding(Visibility::Private)? {
+                Some(binding) => Ok(Ast::Binding(binding?)),
+                None => self.parse_logic_or(),
             }
         } else {
             self.parse_logic_or()

--- a/src/parse/top_level.rs
+++ b/src/parse/top_level.rs
@@ -10,17 +10,20 @@ impl Parser {
         while !self.is_end() {
             match self.parse_top_level(&mut module) {
                 Ok(_) => {
-                    // Note (Ron 5/7/2022): This piece of code requires semicolons after top level items.
-                    //             This isn't semantically required, but was placed for orthogonallity.
-                    //             For now, this proved to be a bit tedious, so I removed it.
-                    // if let Err(_) = require!(self, Semicolon, ";") {
-                    //     let span = Parser::get_missing_delimiter_span(self.previous_span());
-                    //     self.cache
-                    //         .lock()
-                    //         .diagnostics
-                    //         .push(SyntaxError::expected(span, ";"));
-                    //     self.skip_until_recovery_point();
-                    // }
+                    // Note (Ron 20/07/2022):
+                    // This piece of code requires semicolons for top level items.
+                    // This is not semantically required, but is placed for orthogonallity.
+                    // I did experiment with optional semicolon, but they ended up
+                    // add much more complexity then benefit.
+                    // Especially since the language is expression-based.
+                    if let Err(_) = require!(self, Semicolon, ";") {
+                        let span = Parser::get_missing_delimiter_span(self.previous_span());
+                        self.cache
+                            .lock()
+                            .diagnostics
+                            .push(SyntaxError::expected(span, ";"));
+                        self.skip_until_recovery_point();
+                    }
                 }
                 Err(diag) => {
                     self.cache.lock().diagnostics.push(diag);

--- a/src/parse/top_level.rs
+++ b/src/parse/top_level.rs
@@ -45,18 +45,16 @@ impl Parser {
         };
 
         if eat!(self, Let) {
-            let start_span = self.previous_span();
-
-            let binding = if eat!(self, Extern) {
-                self.parse_extern(visibility, start_span)?
-            } else if eat!(self, Intrinsic) {
-                self.parse_builtin_binding(visibility, start_span)?
-            } else {
-                self.parse_binding(visibility)?
-            };
-
+            let binding = self.parse_binding(visibility)?;
             module.bindings.push(binding);
-
+            Ok(())
+        } else if eat!(self, Extern) {
+            let binding = self.parse_extern_binding(visibility)?;
+            module.bindings.push(binding);
+            Ok(())
+        } else if eat!(self, Intrinsic) {
+            let binding = self.parse_intrinsic_binding(visibility)?;
+            module.bindings.push(binding);
             Ok(())
         } else if eat!(self, Ident(_)) {
             let token = self.previous().clone();

--- a/src/token/lexer.rs
+++ b/src/token/lexer.rs
@@ -508,32 +508,7 @@ impl<'lx> Lexer<'lx> {
             self.bump();
         }
 
-        match self.source.range(self.cursor) {
-            "nil" => Nil,
-            "true" => True,
-            "false" => False,
-            "if" => If,
-            "else" => Else,
-            "while" => While,
-            "for" => For,
-            "break" => Break,
-            "continue" => Continue,
-            "return" => Return,
-            "let" => Let,
-            "fn" => Fn,
-            "import" => Import,
-            "extern" => Extern,
-            "intrinsic" => Intrinsic,
-            "pub" => Pub,
-            "mut" => Mut,
-            "in" => In,
-            "as" => As,
-            "struct" => Struct,
-            "union" => Union,
-            "match" => Match,
-            "_" => Placeholder,
-            l => Ident(ustr(l)),
-        }
+        TokenKind::from(self.source.range(self.cursor))
     }
 
     fn peek_two(&self) -> &str {

--- a/src/token/mod.rs
+++ b/src/token/mod.rs
@@ -80,6 +80,7 @@ pub enum TokenKind {
     GtGtEq,
     Dot,
     DotDot,
+    DotDotDot,
     RightArrow,
 
     // Keywords
@@ -171,6 +172,7 @@ impl TokenKind {
             GtGtEq => ">>=",
             Dot => ".",
             DotDot => "..",
+            DotDotDot => "...",
             RightArrow => "->",
             If => "if",
             Else => "else",

--- a/src/token/mod.rs
+++ b/src/token/mod.rs
@@ -92,6 +92,7 @@ pub enum TokenKind {
     Continue,
     Return,
     Let,
+    Static,
     Fn,
     Import,
     Extern,
@@ -120,6 +121,40 @@ pub enum TokenKind {
     // Misc
     Unknown(char),
     Eof,
+}
+
+impl From<&str> for TokenKind {
+    fn from(s: &str) -> Self {
+        use TokenKind::*;
+
+        match s {
+            "nil" => Nil,
+            "true" => True,
+            "false" => False,
+            "if" => If,
+            "else" => Else,
+            "while" => While,
+            "for" => For,
+            "break" => Break,
+            "continue" => Continue,
+            "return" => Return,
+            "let" => Let,
+            "static" => Static,
+            "fn" => Fn,
+            "import" => Import,
+            "extern" => Extern,
+            "intrinsic" => Intrinsic,
+            "pub" => Pub,
+            "mut" => Mut,
+            "in" => In,
+            "as" => As,
+            "struct" => Struct,
+            "union" => Union,
+            "match" => Match,
+            "_" => Placeholder,
+            s => Ident(ustr(s)),
+        }
+    }
 }
 
 impl TokenKind {
@@ -182,6 +217,7 @@ impl TokenKind {
             Continue => "continue",
             Return => "return",
             Let => "let",
+            Static => "static",
             Fn => "fn",
             Import => "import",
             Extern => "extern",

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -117,6 +117,7 @@ pub struct FunctionTypeParam {
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct FunctionTypeVarargs {
+    pub name: Ustr,
     pub ty: Option<Type>,
 }
 
@@ -271,12 +272,22 @@ impl From<Type> for String {
 }
 
 impl Type {
-    pub fn inner(&self) -> &Type {
+    pub fn as_inner(&self) -> &Type {
         match self {
             Type::Pointer(inner, _)
             | Type::Array(inner, _)
             | Type::Slice(inner)
             | Type::Type(inner) => inner,
+            _ => panic!("type {} doesn't have an inner type", self),
+        }
+    }
+
+    pub fn into_inner(self) -> Type {
+        match self {
+            Type::Pointer(inner, _)
+            | Type::Array(inner, _)
+            | Type::Slice(inner)
+            | Type::Type(inner) => *inner,
             _ => panic!("type {} doesn't have an inner type", self),
         }
     }
@@ -401,6 +412,20 @@ impl Type {
         match self {
             Type::Function(ty) => ty,
             _ => panic!("expected fn, got {:?}", self),
+        }
+    }
+
+    pub fn as_type(&self) -> &Type {
+        match self {
+            Type::Type(ty) => ty,
+            _ => panic!("expected type, got {:?}", self),
+        }
+    }
+
+    pub fn into_type(self) -> Type {
+        match self {
+            Type::Type(ty) => *ty,
+            _ => panic!("expected type, got {:?}", self),
         }
     }
 

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -444,6 +444,38 @@ impl Type {
         }
     }
 
+    pub fn is_extern(&self) -> bool {
+        match self {
+            Type::Never
+            | Type::Unit
+            | Type::Bool
+            | Type::Int(_)
+            | Type::Uint(_)
+            | Type::Float(_) => true,
+
+            Type::Module(_)
+            | Type::Slice(_)
+            | Type::Type(_)
+            | Type::AnyType
+            | Type::Var(_)
+            | Type::Infer(_, _) => false,
+
+            Type::Pointer(inner, _) | Type::Array(inner, _) => inner.is_extern(),
+
+            Type::Function(f) => {
+                f.return_type.is_extern()
+                    && f.varargs
+                        .as_ref()
+                        .map_or(true, |v| v.ty.as_ref().map_or(true, Self::is_extern))
+                    && f.params.iter().map(|p| &p.ty).all(Self::is_extern)
+            }
+
+            Type::Tuple(tys) => tys.iter().all(Self::is_extern),
+
+            Type::Struct(st) => st.fields.iter().all(|f| f.ty.is_extern()),
+        }
+    }
+
     #[inline]
     pub fn unit() -> Type {
         Type::Unit

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -78,6 +78,7 @@ pub struct BindingInfo {
 #[derive(Debug, PartialEq, Clone, Copy)]
 pub enum BindingInfoKind {
     Orphan,
+    Static,
     ExternFunction,
     ExternVariable,
     Intrinsic,
@@ -86,7 +87,13 @@ pub enum BindingInfoKind {
 impl From<&BindingKind> for BindingInfoKind {
     fn from(kind: &BindingKind) -> Self {
         match kind {
-            BindingKind::Orphan { .. } => BindingInfoKind::Orphan,
+            BindingKind::Orphan { is_static, .. } => {
+                if *is_static {
+                    BindingInfoKind::Static
+                } else {
+                    BindingInfoKind::Orphan
+                }
+            }
             BindingKind::ExternFunction { .. } => BindingInfoKind::ExternFunction,
             BindingKind::ExternVariable { .. } => BindingInfoKind::ExternVariable,
             BindingKind::Intrinsic { .. } => BindingInfoKind::Intrinsic,


### PR DESCRIPTION
* Made top level semicolons mandatory again
* Added extra check to function signatures
* Change variadic parameter syntax from `..arg: type` to `arg: type...`
* Added explicit static initialization using the `static` keyword before `let` 