### PR TITLE
Add extern attributes

### DIFF
--- a/examples/playground/src/main.chl
+++ b/examples/playground/src/main.chl
@@ -1,4 +1,9 @@
+#[lib = "../../../local_resources/libfoo.a"]
+#[dylib = "../../../local_resources/libfoo.so"]
+pub extern let foo = fn;
+
 #[entry]
 let main = fn() {
     println("Hello World");
+    foo();
 };

--- a/examples/playground/src/main.chl
+++ b/examples/playground/src/main.chl
@@ -1,9 +1,4 @@
-#[lib = "../../../local_resources/libfoo.a"]
-#[dylib = "../../../local_resources/libfoo.so"]
-pub extern let foo = fn;
-
 #[entry]
 let main = fn() {
     println("Hello World");
-    foo();
 };

--- a/lib/std/c.chl
+++ b/lib/std/c.chl
@@ -1,36 +1,76 @@
-pub extern "c" let putchar = fn(char: int) -> int;
-pub extern "c" let getchar = fn() -> int;
+let LIB = "c";
 
-pub extern "c" let printf = fn(input: *u8, args...) -> int;
-pub extern "c" let sprintf_s = fn(buffer: *u8, sizeOfBuffer: uint, format: *u8, args...) -> int;
+#[lib = LIB]
+pub extern let putchar = fn(char: int) -> int;
 
-pub extern "c" let strcpy = fn(dest: *u8, src: *u8) -> *u8;
+#[lib = LIB]
+pub extern let getchar = fn() -> int;
 
-pub extern "c" let malloc = fn(size: uint) -> *i8;
-pub extern "c" let calloc = fn(nitems: uint, size: uint) -> *i8;
-pub extern "c" let realloc = fn(ptr: *i8, size: uint) -> *i8;
-pub extern "c" let free = fn(memblock: *i8);
+#[lib = LIB]
+pub extern let printf = fn(input: *u8, args...) -> int;
 
-pub extern "c" let abs = fn(x: i32) -> i32;
+#[lib = LIB]
+pub extern let sprintf_s = fn(buffer: *u8, sizeOfBuffer: uint, format: *u8, args...) -> int;
 
-pub extern "c" let sinf = fn(arg: f32) -> f32;
-pub extern "c" let sin = fn(arg: f64) -> f64;
+#[lib = LIB]
+pub extern let strcpy = fn(dest: *u8, src: *u8) -> *u8;
 
-pub extern "c" let cosf = fn(arg: f32) -> f32;
-pub extern "c" let cos = fn(arg: f64) -> f64;
+#[lib = LIB]
+pub extern let malloc = fn(size: uint) -> *i8;
 
-pub extern "c" let atan2f = fn(y: f32, x: f32) -> f32;
-pub extern "c" let atan2 = fn(y: f64, x: f64) -> f64;
+#[lib = LIB]
+pub extern let calloc = fn(nitems: uint, size: uint) -> *i8;
 
-pub extern "c" let pow = fn(x: f64, y: f64) -> f64;
+#[lib = LIB]
+pub extern let realloc = fn(ptr: *i8, size: uint) -> *i8;
 
-pub extern "c" let srand = fn(seed: uint);
-pub extern "c" let rand = fn() -> uint;
-pub extern "c" let time = fn(some: *i8) -> uint;
+#[lib = LIB]
+pub extern let free = fn(memblock: *i8);
 
-pub extern "c" let fork = fn() -> int;
-pub extern "c" let waitpid = fn(pid: int, status: *mut int, options: int) -> int;
-pub extern "c" let execl = fn(path: *u8, args...) -> int;
+#[lib = LIB]
+pub extern let abs = fn(x: i32) -> i32;
 
-pub extern "c" let abort = fn() -> never;
-pub extern "c" let exit = fn(status: int) -> never;
+#[lib = LIB]
+pub extern let sinf = fn(arg: f32) -> f32;
+
+#[lib = LIB]
+pub extern let sin = fn(arg: f64) -> f64;
+
+#[lib = LIB]
+pub extern let cosf = fn(arg: f32) -> f32;
+
+#[lib = LIB]
+pub extern let cos = fn(arg: f64) -> f64;
+
+#[lib = LIB]
+pub extern let atan2f = fn(y: f32, x: f32) -> f32;
+
+#[lib = LIB]
+pub extern let atan2 = fn(y: f64, x: f64) -> f64;
+
+#[lib = LIB]
+pub extern let pow = fn(x: f64, y: f64) -> f64;
+
+#[lib = LIB]
+pub extern let srand = fn(seed: uint);
+
+#[lib = LIB]
+pub extern let rand = fn() -> uint;
+
+#[lib = LIB]
+pub extern let time = fn(some: *i8) -> uint;
+
+#[lib = LIB]
+pub extern let fork = fn() -> int;
+
+#[lib = LIB]
+pub extern let waitpid = fn(pid: int, status: *mut int, options: int) -> int;
+
+#[lib = LIB]
+pub extern let execl = fn(path: *u8, args...) -> int;
+
+#[lib = LIB]
+pub extern let abort = fn() -> never;
+
+#[lib = LIB]
+pub extern let exit = fn(status: int) -> never;

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -469,6 +469,7 @@ impl ExternLibrary {
         }
     }
 
+    #[allow(unused)]
     pub fn from_str(s: &str, relative_to: &RelativeTo<'_>) -> Self {
         let path = Path::new(s);
 

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -459,11 +459,7 @@ impl ExternLibraryPath {
 }
 
 impl ExternLibrary {
-    pub fn try_from_str(
-        s: &str,
-        relative_to: RelativeTo<'_>,
-        span: Span,
-    ) -> DiagnosticResult<Self> {
+    pub fn try_from_str(s: &str, relative_to: RelativeTo<'_>, span: Span) -> DiagnosticResult<Self> {
         let path = Path::new(s);
 
         if path.extension().is_some() {
@@ -473,10 +469,6 @@ impl ExternLibrary {
             let lib = s.to_string();
             Ok(ExternLibrary::System(lib))
         }
-    }
-
-    pub fn from_str(from: &str, relative_to: RelativeTo<'_>) -> Option<Self> {
-        Self::try_from_str(from, relative_to, Span::unknown()).ok()
     }
 
     pub fn path(&self) -> String {

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -2,7 +2,7 @@ pub mod pattern;
 
 use self::pattern::NamePattern;
 use crate::{
-    common::path::{try_resolve_relative_path, RelativeTo},
+    common::path::{resolve_relative_path, try_resolve_relative_path, RelativeTo},
     define_id_type,
     error::DiagnosticResult,
     span::{FileId, Span},
@@ -459,15 +459,25 @@ impl ExternLibraryPath {
 }
 
 impl ExternLibrary {
-    pub fn try_from_str(s: &str, relative_to: RelativeTo<'_>, span: Span) -> DiagnosticResult<Self> {
+    pub fn try_from_str(s: &str, relative_to: &RelativeTo<'_>, span: Span) -> DiagnosticResult<Self> {
         let path = Path::new(s);
 
-        if path.extension().is_some() {
-            let path = try_resolve_relative_path(Path::new(s), relative_to, Some(span))?;
-            Ok(ExternLibrary::Path(ExternLibraryPath { path }))
+        if s.starts_with(&['.', '/', '\\']) || path.has_root() || path.extension().is_some() {
+            try_resolve_relative_path(path, relative_to, Some(span)).map(|path| Self::Path(ExternLibraryPath { path }))
         } else {
-            let lib = s.to_string();
-            Ok(ExternLibrary::System(lib))
+            Ok(Self::System(s.to_string()))
+        }
+    }
+
+    pub fn from_str(s: &str, relative_to: &RelativeTo<'_>) -> Self {
+        let path = Path::new(s);
+
+        if s.starts_with(&['.', '/', '\\']) || path.has_root() || path.extension().is_some() {
+            Self::Path(ExternLibraryPath {
+                path: resolve_relative_path(path, relative_to),
+            })
+        } else {
+            Self::System(s.to_string())
         }
     }
 
@@ -498,12 +508,10 @@ pub enum BindingKind {
     },
     ExternFunction {
         name: NameAndSpan,
-        lib: Option<ExternLibrary>,
         sig: FunctionSig,
     },
     ExternVariable {
         name: NameAndSpan,
-        lib: Option<ExternLibrary>,
         is_mutable: bool,
         type_expr: Box<Ast>,
     },

--- a/src/ast/pattern.rs
+++ b/src/ast/pattern.rs
@@ -54,10 +54,7 @@ impl Pattern {
     }
 
     pub fn iter(&self) -> PatternIter {
-        PatternIter {
-            pattern: self,
-            pos: 0,
-        }
+        PatternIter { pattern: self, pos: 0 }
     }
 
     #[allow(unused)]
@@ -96,9 +93,7 @@ impl<'a> Iterator for PatternIter<'a> {
                 0 => Some(pattern),
                 _ => None,
             },
-            Pattern::StructUnpack(pattern) | Pattern::TupleUnpack(pattern) => {
-                pattern.symbols.get(self.pos)
-            }
+            Pattern::StructUnpack(pattern) | Pattern::TupleUnpack(pattern) => pattern.symbols.get(self.pos),
             Pattern::Hybrid(pattern) => match self.pos {
                 0 => Some(&pattern.name_pattern),
                 _ => pattern.unpack_pattern.as_inner().symbols.get(self.pos - 1),
@@ -159,12 +154,7 @@ pub struct NamePattern {
 
 impl Display for NamePattern {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "{}{}",
-            if self.is_mutable { "mut " } else { "" },
-            self.alias()
-        )
+        write!(f, "{}{}", if self.is_mutable { "mut " } else { "" }, self.alias())
     }
 }
 

--- a/src/astgen/mod.rs
+++ b/src/astgen/mod.rs
@@ -20,10 +20,9 @@ pub struct AstGenerationStats {
 pub type AstGenerationResult = Option<(Vec<ast::Module>, AstGenerationStats)>;
 
 pub fn generate_ast(workspace: &mut Workspace) -> AstGenerationResult {
-    let root_file_path =
-        try_resolve_relative_path(&workspace.build_options.source_file, RelativeTo::Cwd, None)
-            .map_err(|diag| workspace.diagnostics.push(diag))
-            .ok()?;
+    let root_file_path = try_resolve_relative_path(&workspace.build_options.source_file, RelativeTo::Cwd, None)
+        .map_err(|diag| workspace.diagnostics.push(diag))
+        .ok()?;
 
     let (mut modules, stats) = generate_ast_inner(workspace, root_file_path.clone());
 
@@ -43,15 +42,11 @@ pub fn generate_ast(workspace: &mut Workspace) -> AstGenerationResult {
     Some((modules, stats))
 }
 
-fn generate_ast_inner(
-    workspace: &mut Workspace,
-    root_file_path: PathBuf,
-) -> (Vec<ast::Module>, AstGenerationStats) {
+fn generate_ast_inner(workspace: &mut Workspace, root_file_path: PathBuf) -> (Vec<ast::Module>, AstGenerationStats) {
     let mut modules: Vec<ast::Module> = vec![];
 
     let cache = Arc::new(Mutex::new(ParserCache {
-        root_file: resolve_relative_path(&workspace.build_options.source_file, RelativeTo::Cwd)
-            .unwrap(),
+        root_file: resolve_relative_path(&workspace.build_options.source_file, RelativeTo::Cwd).unwrap(),
         root_dir: workspace.root_dir.clone(),
         std_dir: workspace.std_dir.clone(),
         include_paths: workspace.build_options.include_paths.clone(),
@@ -72,12 +67,7 @@ fn generate_ast_inner(
         compiler_info::std_module_info(),
     );
 
-    spawn_parser(
-        thread_pool.clone(),
-        tx,
-        Arc::clone(&cache),
-        root_module_info,
-    );
+    spawn_parser(thread_pool.clone(), tx, Arc::clone(&cache), root_module_info);
 
     for result in rx.iter() {
         match *result {

--- a/src/backend/llvm/abi/amd64_system_v.rs
+++ b/src/backend/llvm/abi/amd64_system_v.rs
@@ -13,10 +13,7 @@ pub(super) fn get_fn<'ctx>(info: AbiInfo<'ctx>, fn_ty: FunctionType<'ctx>) -> Ab
     }
 }
 
-pub(super) fn get_params<'ctx>(
-    info: AbiInfo<'ctx>,
-    params: Vec<BasicTypeEnum<'ctx>>,
-) -> Vec<AbiTy<'ctx>> {
+pub(super) fn get_params<'ctx>(info: AbiInfo<'ctx>, params: Vec<BasicTypeEnum<'ctx>>) -> Vec<AbiTy<'ctx>> {
     params
         .iter()
         .map(|&param| amd64_sysv_type(info, param, Amd64TypeAttributeKind::ByVal))
@@ -51,9 +48,7 @@ impl RegClass {
     fn is_sse(&self) -> bool {
         match self {
             RegClass::SSEFs | RegClass::SSEFv | RegClass::SSEDs | RegClass::SSEDv => true,
-            RegClass::SSEInt8 | RegClass::SSEInt16 | RegClass::SSEInt32 | RegClass::SSEInt64 => {
-                true
-            }
+            RegClass::SSEInt8 | RegClass::SSEInt16 | RegClass::SSEInt32 | RegClass::SSEInt64 => true,
             _ => false,
         }
     }
@@ -75,12 +70,7 @@ fn is_mem_class(classes: &[RegClass], attr_kind: Amd64TypeAttributeKind) -> bool
     match attr_kind {
         Amd64TypeAttributeKind::ByVal => classes
             .first()
-            .map(|class| {
-                matches!(
-                    class,
-                    RegClass::Memory | RegClass::X87 | RegClass::ComplexX87
-                )
-            })
+            .map(|class| matches!(class, RegClass::Memory | RegClass::X87 | RegClass::ComplexX87))
             .unwrap_or(false),
         Amd64TypeAttributeKind::StructRect => classes
             .first()
@@ -111,10 +101,10 @@ fn amd64_sysv_type<'ctx>(
             if attr_kind == Amd64TypeAttributeKind::ByVal {
                 AbiTy::indirect_byval(&info.context, ty, info.word_size)
             } else if attr_kind == Amd64TypeAttributeKind::StructRect {
-                *AbiTy::indirect(ty).with_attr(info.context.create_type_attribute(
-                    Attribute::get_named_enum_kind_id("sret"),
-                    ty.as_any_type_enum(),
-                ))
+                *AbiTy::indirect(ty).with_attr(
+                    info.context
+                        .create_type_attribute(Attribute::get_named_enum_kind_id("sret"), ty.as_any_type_enum()),
+                )
             } else {
                 AbiTy::indirect(ty)
             }
@@ -201,15 +191,7 @@ fn classify_type_with_classes<'ctx>(
             let el_align = size_of(el_ty, info.word_size);
 
             for i in 0..len {
-                classify_type_with_classes(
-                    info,
-                    classes,
-                    el_ty,
-                    el_size,
-                    el_align,
-                    index,
-                    offset + i * el_size,
-                );
+                classify_type_with_classes(info, classes, el_ty, el_size, el_align, index, offset + i * el_size);
             }
         }
         BasicTypeEnum::StructType(st) => {
@@ -225,15 +207,7 @@ fn classify_type_with_classes<'ctx>(
                     field_offset = calculate_align_from_offset(field_offset, field_align);
                 }
 
-                classify_type_with_classes(
-                    info,
-                    classes,
-                    field_ty,
-                    field_size,
-                    field_align,
-                    index,
-                    field_offset,
-                );
+                classify_type_with_classes(info, classes, field_ty, field_size, field_align, index, field_offset);
 
                 field_offset += field_size;
             }
@@ -258,15 +232,9 @@ fn unify_classes(classes: &mut [RegClass], index: usize, new_class: RegClass) {
         RegClass::Memory
     } else if old_class == RegClass::Int || new_class == RegClass::Int {
         RegClass::Int
-    } else if old_class == RegClass::X87
-        || old_class == RegClass::X87Up
-        || old_class == RegClass::ComplexX87
-    {
+    } else if old_class == RegClass::X87 || old_class == RegClass::X87Up || old_class == RegClass::ComplexX87 {
         RegClass::Memory
-    } else if new_class == RegClass::X87
-        || new_class == RegClass::X87Up
-        || new_class == RegClass::ComplexX87
-    {
+    } else if new_class == RegClass::X87 || new_class == RegClass::X87Up || new_class == RegClass::ComplexX87 {
         RegClass::Memory
     } else if new_class == RegClass::SSEUp {
         match old_class {
@@ -293,9 +261,7 @@ fn fixup_classes<'ctx>(classes: &mut [RegClass], ty: BasicTypeEnum<'ctx>) {
     if end > 2
         && matches!(
             ty,
-            BasicTypeEnum::StructType(_)
-                | BasicTypeEnum::ArrayType(_)
-                | BasicTypeEnum::VectorType(_)
+            BasicTypeEnum::StructType(_) | BasicTypeEnum::ArrayType(_) | BasicTypeEnum::VectorType(_)
         )
     {
         let old_class = classes[0];

--- a/src/backend/llvm/abi/amd64_win64.rs
+++ b/src/backend/llvm/abi/amd64_win64.rs
@@ -10,18 +10,16 @@ pub(super) fn get_fn<'ctx>(info: AbiInfo<'ctx>, fn_ty: FunctionType<'ctx>) -> Ab
     }
 }
 
-pub(super) fn get_params<'ctx>(
-    info: AbiInfo<'ctx>,
-    params: Vec<BasicTypeEnum<'ctx>>,
-) -> Vec<AbiTy<'ctx>> {
+pub(super) fn get_params<'ctx>(info: AbiInfo<'ctx>, params: Vec<BasicTypeEnum<'ctx>>) -> Vec<AbiTy<'ctx>> {
     params
         .iter()
         .map(|&param| {
             if param.is_aggregate_type() {
                 let size = size_of(param, info.word_size);
                 match size {
-                    0 | 1 | 2 | 4 | 8 => *AbiTy::direct(param)
-                        .with_cast_to(info.context.custom_width_int_type((8 * size) as u32).into()),
+                    0 | 1 | 2 | 4 | 8 => {
+                        *AbiTy::direct(param).with_cast_to(info.context.custom_width_int_type((8 * size) as u32).into())
+                    }
                     _ => AbiTy::indirect(param),
                 }
             } else {

--- a/src/backend/llvm/abi/i386.rs
+++ b/src/backend/llvm/abi/i386.rs
@@ -15,10 +15,7 @@ pub(super) fn get_fn<'ctx>(info: AbiInfo<'ctx>, fn_ty: FunctionType<'ctx>) -> Ab
 }
 
 #[allow(unused)]
-pub(super) fn get_params<'ctx>(
-    info: AbiInfo<'ctx>,
-    params: Vec<BasicTypeEnum<'ctx>>,
-) -> Vec<AbiTy<'ctx>> {
+pub(super) fn get_params<'ctx>(info: AbiInfo<'ctx>, params: Vec<BasicTypeEnum<'ctx>>) -> Vec<AbiTy<'ctx>> {
     params
         .iter()
         .map(|&param| {
@@ -45,21 +42,17 @@ pub(super) fn get_return<'ctx>(info: AbiInfo<'ctx>, ret: BasicTypeEnum<'ctx>) ->
             2 => AbiTy::direct(info.context.i16_type().into()),
             4 => AbiTy::direct(info.context.i32_type().into()),
             8 => AbiTy::direct(info.context.i64_type().into()),
-            _ => *AbiTy::indirect(ret).with_attr(info.context.create_type_attribute(
-                Attribute::get_named_enum_kind_id("sret"),
-                ret.as_any_type_enum(),
-            )),
+            _ => *AbiTy::indirect(ret).with_attr(
+                info.context
+                    .create_type_attribute(Attribute::get_named_enum_kind_id("sret"), ret.as_any_type_enum()),
+            ),
         }
     } else {
         non_struct(info, ret, true)
     }
 }
 
-pub(super) fn non_struct<'ctx>(
-    info: AbiInfo<'ctx>,
-    ty: BasicTypeEnum<'ctx>,
-    is_return: bool,
-) -> AbiTy<'ctx> {
+pub(super) fn non_struct<'ctx>(info: AbiInfo<'ctx>, ty: BasicTypeEnum<'ctx>, is_return: bool) -> AbiTy<'ctx> {
     if !is_return && size_of(ty, info.word_size) > 8 {
         AbiTy::indirect(ty)
     } else {

--- a/src/backend/llvm/abi/mod.rs
+++ b/src/backend/llvm/abi/mod.rs
@@ -152,19 +152,14 @@ impl<'ctx> AbiTy<'ctx> {
         }
     }
 
-    pub(super) fn indirect_byval(
-        context: &Context,
-        ty: BasicTypeEnum<'ctx>,
-        word_size: usize,
-    ) -> Self {
+    pub(super) fn indirect_byval(context: &Context, ty: BasicTypeEnum<'ctx>, word_size: usize) -> Self {
         Self {
             ty,
             kind: AbiType::Indirect,
             cast_to: None,
-            attr: Some(context.create_type_attribute(
-                Attribute::get_named_enum_kind_id("byval"),
-                ty.as_any_type_enum(),
-            )),
+            attr: Some(
+                context.create_type_attribute(Attribute::get_named_enum_kind_id("byval"), ty.as_any_type_enum()),
+            ),
             align_attr: Some(context.create_enum_attribute(
                 Attribute::get_named_enum_kind_id("align"),
                 align_of(ty, word_size).max(8) as u64,

--- a/src/backend/llvm/codegen.rs
+++ b/src/backend/llvm/codegen.rs
@@ -18,9 +18,7 @@ use inkwell::{
     module::{Linkage, Module},
     passes::{PassManager, PassManagerBuilder},
     types::{BasicTypeEnum, IntType},
-    values::{
-        BasicValue, BasicValueEnum, FunctionValue, GlobalValue, InstructionOpcode, PointerValue,
-    },
+    values::{BasicValue, BasicValueEnum, FunctionValue, GlobalValue, InstructionOpcode, PointerValue},
     OptimizationLevel,
 };
 use std::{
@@ -146,8 +144,7 @@ impl<'g, 'ctx> Generator<'g, 'ctx> {
     pub(super) fn optimize(&mut self) {
         let pass_manager_builder = PassManagerBuilder::create();
 
-        let optimization_level: OptimizationLevel =
-            self.workspace.build_options.optimization_level.into();
+        let optimization_level: OptimizationLevel = self.workspace.build_options.optimization_level.into();
 
         let size_level: u32 = match self.workspace.build_options.optimization_level {
             build_options::OptimizationLevel::Debug => 1,
@@ -181,12 +178,7 @@ impl<'g, 'ctx> Generator<'g, 'ctx> {
         decl
     }
 
-    pub(super) fn add_global(
-        &mut self,
-        id: BindingId,
-        ty: BasicTypeEnum<'ctx>,
-        linkage: Linkage,
-    ) -> GlobalValue<'ctx> {
+    pub(super) fn add_global(&mut self, id: BindingId, ty: BasicTypeEnum<'ctx>, linkage: Linkage) -> GlobalValue<'ctx> {
         let binding_info = self.workspace.binding_infos.get(id).unwrap();
         let global_value = self.module.add_global(ty, None, &binding_info.name);
         global_value.set_linkage(linkage);
@@ -217,11 +209,7 @@ impl<'g, 'ctx> Generator<'g, 'ctx> {
             .unwrap_or_else(|| panic!("couldn't find {} in {}", name, module_name))
     }
 
-    pub(super) fn find_decl_by_name(
-        &mut self,
-        module_name: impl Into<Ustr>,
-        name: impl Into<Ustr>,
-    ) -> Decl<'ctx> {
+    pub(super) fn find_decl_by_name(&mut self, module_name: impl Into<Ustr>, name: impl Into<Ustr>) -> Decl<'ctx> {
         let id = self.find_binding_info_by_name(module_name, name).id;
         self.gen_top_level_binding(id)
     }
@@ -252,12 +240,9 @@ impl<'g, 'ctx> Generator<'g, 'ctx> {
         value: BasicValueEnum<'ctx>,
     ) -> PointerValue<'ctx> {
         match value.as_instruction_value() {
-            Some(inst) if inst.get_opcode() == InstructionOpcode::Load => inst
-                .get_operand(0)
-                .unwrap()
-                .left()
-                .unwrap()
-                .into_pointer_value(),
+            Some(inst) if inst.get_opcode() == InstructionOpcode::Load => {
+                inst.get_operand(0).unwrap().left().unwrap().into_pointer_value()
+            }
             _ => self.local_with_alloca(state, id, value),
         }
     }
@@ -268,12 +253,9 @@ impl<'g, 'ctx> Generator<'g, 'ctx> {
         value: BasicValueEnum<'ctx>,
     ) -> PointerValue<'ctx> {
         match value.as_instruction_value() {
-            Some(inst) if inst.get_opcode() == InstructionOpcode::Load => inst
-                .get_operand(0)
-                .unwrap()
-                .left()
-                .unwrap()
-                .into_pointer_value(),
+            Some(inst) if inst.get_opcode() == InstructionOpcode::Load => {
+                inst.get_operand(0).unwrap().left().unwrap().into_pointer_value()
+            }
             _ => {
                 let ptr = self.build_alloca(state, value.get_type());
                 self.build_store(ptr, value);
@@ -282,17 +264,8 @@ impl<'g, 'ctx> Generator<'g, 'ctx> {
         }
     }
 
-    fn gen_local_inner(
-        &mut self,
-        state: &mut FunctionState<'ctx>,
-        id: BindingId,
-        ptr: PointerValue<'ctx>,
-    ) {
-        let name = self
-            .workspace
-            .binding_infos
-            .get(id)
-            .map_or(ustr(""), |b| b.name);
+    fn gen_local_inner(&mut self, state: &mut FunctionState<'ctx>, id: BindingId, ptr: PointerValue<'ctx>) {
+        let name = self.workspace.binding_infos.get(id).map_or(ustr(""), |b| b.name);
 
         ptr.set_name(&name);
 
@@ -301,10 +274,7 @@ impl<'g, 'ctx> Generator<'g, 'ctx> {
             self.target_metrics.word_size,
         );
 
-        ptr.as_instruction_value()
-            .unwrap()
-            .set_alignment(align as u32)
-            .unwrap();
+        ptr.as_instruction_value().unwrap().set_alignment(align as u32).unwrap();
 
         if id != BindingId::unknown() {
             state.scopes.insert(id, Decl::Local(ptr));
@@ -319,11 +289,7 @@ impl<'g, 'ctx> Generator<'g, 'ctx> {
     ) -> BasicValueEnum<'ctx> {
         match const_value {
             ConstValue::Unit(_) | ConstValue::Type(_) => self.unit_value(),
-            ConstValue::Bool(v) => self
-                .context
-                .bool_type()
-                .const_int(if *v { 1 } else { 0 }, false)
-                .into(),
+            ConstValue::Bool(v) => self.context.bool_type().const_int(if *v { 1 } else { 0 }, false).into(),
             ConstValue::Int(v) => {
                 if ty.is_any_integer() {
                     ty.llvm_type(self)
@@ -331,10 +297,7 @@ impl<'g, 'ctx> Generator<'g, 'ctx> {
                         .const_int(*v as u64, ty.is_signed_int())
                         .into()
                 } else {
-                    ty.llvm_type(self)
-                        .into_float_type()
-                        .const_float(*v as f64)
-                        .into()
+                    ty.llvm_type(self).into_float_type().const_float(*v as f64).into()
                 }
             }
             ConstValue::Uint(v) => {
@@ -344,17 +307,10 @@ impl<'g, 'ctx> Generator<'g, 'ctx> {
                         .const_int(*v, ty.is_signed_int())
                         .into()
                 } else {
-                    ty.llvm_type(self)
-                        .into_float_type()
-                        .const_float(*v as f64)
-                        .into()
+                    ty.llvm_type(self).into_float_type().const_float(*v as f64).into()
                 }
             }
-            ConstValue::Float(v) => ty
-                .llvm_type(self)
-                .into_float_type()
-                .const_float(*v as f64)
-                .into(),
+            ConstValue::Float(v) => ty.llvm_type(self).into_float_type().const_float(*v as f64).into(),
             ConstValue::Str(v) => self.const_str_slice("", *v).into(),
             ConstValue::Array(array) => {
                 let el_ty = array.element_ty.normalize(self.tcx);
@@ -370,9 +326,7 @@ impl<'g, 'ctx> Generator<'g, 'ctx> {
             ConstValue::Tuple(elements) => {
                 let values = elements
                     .iter()
-                    .map(|element| {
-                        self.gen_const_value(state, &element.value, &element.ty.normalize(self.tcx))
-                    })
+                    .map(|element| self.gen_const_value(state, &element.value, &element.ty.normalize(self.tcx)))
                     .collect::<Vec<BasicValueEnum>>();
 
                 self.const_struct(&values).into()
@@ -380,16 +334,11 @@ impl<'g, 'ctx> Generator<'g, 'ctx> {
             ConstValue::Struct(fields) => {
                 let values = fields
                     .values()
-                    .map(|element| {
-                        self.gen_const_value(state, &element.value, &element.ty.normalize(self.tcx))
-                    })
+                    .map(|element| self.gen_const_value(state, &element.value, &element.ty.normalize(self.tcx)))
                     .collect::<Vec<BasicValueEnum>>();
 
                 // self.context.const_struct(&values, false).into();
-                ty.llvm_type(self)
-                    .into_struct_type()
-                    .const_named_struct(&values)
-                    .into()
+                ty.llvm_type(self).into_struct_type().const_named_struct(&values).into()
             }
             ConstValue::Function(function) => {
                 let prev_block = if let Some(state) = state {
@@ -411,20 +360,16 @@ impl<'g, 'ctx> Generator<'g, 'ctx> {
                     self.extern_libraries.insert(lib.clone());
                 }
 
-                let global_value = self
-                    .extern_variables
-                    .get(&variable.name)
-                    .cloned()
-                    .unwrap_or_else(|| {
-                        let llvm_type = variable.ty.llvm_type(self);
+                let global_value = self.extern_variables.get(&variable.name).cloned().unwrap_or_else(|| {
+                    let llvm_type = variable.ty.llvm_type(self);
 
-                        let global_value = self.module.add_global(llvm_type, None, &variable.name);
-                        global_value.set_linkage(Linkage::External);
+                    let global_value = self.module.add_global(llvm_type, None, &variable.name);
+                    global_value.set_linkage(Linkage::External);
 
-                        self.extern_variables.insert(variable.name, global_value);
+                    self.extern_variables.insert(variable.name, global_value);
 
-                        global_value
-                    });
+                    global_value
+                });
 
                 let ptr = global_value.as_pointer_value();
 
@@ -433,11 +378,7 @@ impl<'g, 'ctx> Generator<'g, 'ctx> {
         }
     }
 
-    pub(super) fn gen_return(
-        &mut self,
-        state: &mut FunctionState<'ctx>,
-        value: Option<BasicValueEnum<'ctx>>,
-    ) {
+    pub(super) fn gen_return(&mut self, state: &mut FunctionState<'ctx>, value: Option<BasicValueEnum<'ctx>>) {
         let abi_fn = self.get_abi_compliant_fn(&state.fn_type);
 
         if abi_fn.ret.kind.is_indirect() {
@@ -466,11 +407,7 @@ impl<'g, 'ctx> Generator<'g, 'ctx> {
         } else {
             let value = value.unwrap_or_else(|| self.unit_value());
 
-            let value = self.build_transmute(
-                state,
-                value,
-                state.function.get_type().get_return_type().unwrap(),
-            );
+            let value = self.build_transmute(state, value, state.function.get_type().get_return_type().unwrap());
 
             self.builder.build_return(Some(&value));
         }
@@ -481,11 +418,7 @@ pub(super) trait Codegen<'g, 'ctx>
 where
     Self: Debug,
 {
-    fn codegen(
-        &self,
-        generator: &mut Generator<'g, 'ctx>,
-        state: &mut FunctionState<'ctx>,
-    ) -> BasicValueEnum<'ctx>;
+    fn codegen(&self, generator: &mut Generator<'g, 'ctx>, state: &mut FunctionState<'ctx>) -> BasicValueEnum<'ctx>;
 
     fn codegen_global(&self, _generator: &mut Generator<'g, 'ctx>) -> Decl<'ctx> {
         unimplemented!("{:?}", self)

--- a/src/backend/llvm/codegen.rs
+++ b/src/backend/llvm/codegen.rs
@@ -356,7 +356,7 @@ impl<'g, 'ctx> Generator<'g, 'ctx> {
                 function_value.as_global_value().as_pointer_value().into()
             }
             ConstValue::ExternVariable(variable) => {
-                if let Some(lib) = &variable.lib {
+                if let Some(lib) = variable.lib.as_ref().or(variable.dylib.as_ref()) {
                     self.extern_libraries.insert(lib.clone());
                 }
 

--- a/src/backend/llvm/codegen_builtin.rs
+++ b/src/backend/llvm/codegen_builtin.rs
@@ -15,11 +15,7 @@ use inkwell::{
 };
 
 impl<'g, 'ctx> Codegen<'g, 'ctx> for hir::Builtin {
-    fn codegen(
-        &self,
-        generator: &mut Generator<'g, 'ctx>,
-        state: &mut FunctionState<'ctx>,
-    ) -> BasicValueEnum<'ctx> {
+    fn codegen(&self, generator: &mut Generator<'g, 'ctx>, state: &mut FunctionState<'ctx>) -> BasicValueEnum<'ctx> {
         match self {
             hir::Builtin::Add(binary) => {
                 let (lhs, rhs, ty) = gen_binary(binary, generator, state);
@@ -55,25 +51,19 @@ impl<'g, 'ctx> Codegen<'g, 'ctx> for hir::Builtin {
                 generator.gen_conditional(
                     state,
                     |generator, state| binary.lhs.codegen(generator, state).into_int_value(),
-                    |generator, state: &mut FunctionState<'ctx>| {
-                        binary.rhs.codegen(generator, state)
-                    },
-                    Some(
-                        |generator: &mut Generator<'g, 'ctx>, _: &mut FunctionState<'ctx>| {
-                            generator.context.bool_type().const_int(0, false).into()
-                        },
-                    ),
+                    |generator, state: &mut FunctionState<'ctx>| binary.rhs.codegen(generator, state),
+                    Some(|generator: &mut Generator<'g, 'ctx>, _: &mut FunctionState<'ctx>| {
+                        generator.context.bool_type().const_int(0, false).into()
+                    }),
                 )
             }
             hir::Builtin::Or(binary) => generator.gen_conditional(
                 state,
                 |generator, state| binary.lhs.codegen(generator, state).into_int_value(),
                 |generator, _| generator.context.bool_type().const_int(1, false).into(),
-                Some(
-                    |generator: &mut Generator<'g, 'ctx>, state: &mut FunctionState<'ctx>| {
-                        binary.rhs.codegen(generator, state)
-                    },
-                ),
+                Some(|generator: &mut Generator<'g, 'ctx>, state: &mut FunctionState<'ctx>| {
+                    binary.rhs.codegen(generator, state)
+                }),
             ),
             hir::Builtin::Lt(binary) => gen_cmp(
                 binary,
@@ -139,9 +129,7 @@ impl<'g, 'ctx> Codegen<'g, 'ctx> for hir::Builtin {
                 let value = unary.value.codegen(generator, state).into_int_value();
 
                 match unary.ty.normalize(generator.tcx) {
-                    Type::Int(_) | Type::Uint(_) => {
-                        generator.builder.build_not(value, "not").into()
-                    }
+                    Type::Int(_) | Type::Uint(_) => generator.builder.build_not(value, "not").into(),
                     Type::Bool => {
                         let false_value = generator.context.custom_width_int_type(1).const_zero();
 
@@ -215,41 +203,25 @@ fn gen_cmp<'g, 'ctx>(
             .into(),
         Type::Float(_) => generator
             .builder
-            .build_float_compare(
-                float_predicate,
-                lhs.into_float_value(),
-                rhs.into_float_value(),
-                "",
-            )
+            .build_float_compare(float_predicate, lhs.into_float_value(), rhs.into_float_value(), "")
             .into(),
         Type::Pointer(..) => {
-            let lhs = generator.builder.build_ptr_to_int(
-                lhs.into_pointer_value(),
-                generator.ptr_sized_int_type,
-                "",
-            );
-
-            let rhs = generator.builder.build_ptr_to_int(
-                rhs.into_pointer_value(),
-                generator.ptr_sized_int_type,
-                "",
-            );
-
-            generator
+            let lhs = generator
                 .builder
-                .build_int_compare(int_predicate, lhs, rhs, "")
-                .into()
+                .build_ptr_to_int(lhs.into_pointer_value(), generator.ptr_sized_int_type, "");
+
+            let rhs = generator
+                .builder
+                .build_ptr_to_int(rhs.into_pointer_value(), generator.ptr_sized_int_type, "");
+
+            generator.builder.build_int_compare(int_predicate, lhs, rhs, "").into()
         }
         ty => panic!("unexpected type: {}", ty),
     }
 }
 
 impl<'g, 'ctx> Codegen<'g, 'ctx> for hir::Slice {
-    fn codegen(
-        &self,
-        generator: &mut Generator<'g, 'ctx>,
-        state: &mut FunctionState<'ctx>,
-    ) -> BasicValueEnum<'ctx> {
+    fn codegen(&self, generator: &mut Generator<'g, 'ctx>, state: &mut FunctionState<'ctx>) -> BasicValueEnum<'ctx> {
         let value = self.value.codegen(generator, state);
         let value_type = self.value.ty().normalize(generator.tcx);
 
@@ -277,25 +249,13 @@ impl<'g, 'ctx> Codegen<'g, 'ctx> for hir::Slice {
         };
 
         if let Some(len) = len {
-            generator.gen_runtime_check_slice_range_out_of_bounds(
-                state,
-                low,
-                high,
-                len,
-                self.value.span(),
-            );
+            generator.gen_runtime_check_slice_range_out_of_bounds(state, low, high, len, self.value.span());
         }
 
         let slice_llvm_type = self.ty.llvm_type(generator);
         let slice_ptr = generator.build_alloca(state, slice_llvm_type);
 
-        generator.build_slice(
-            slice_ptr,
-            sliced_value,
-            low,
-            high,
-            value_type.element_type().unwrap(),
-        );
+        generator.build_slice(slice_ptr, sliced_value, low, high, value_type.element_type().unwrap());
 
         generator.builder.build_load(slice_ptr, "")
     }
@@ -319,8 +279,7 @@ impl<'g, 'ctx> Generator<'g, 'ctx> {
                     self.builder.build_int_add(lhs, rhs, "add").into()
                 } else {
                     let overflow_fn = self.get_overflow_fn(ast::BinaryOp::Add, ty, lhs.get_type());
-                    let result =
-                        self.gen_call_overflow_fn(state, overflow_fn, lhs, rhs, span, "add");
+                    let result = self.gen_call_overflow_fn(state, overflow_fn, lhs, rhs, span, "add");
                     result.into()
                 }
             }
@@ -354,8 +313,7 @@ impl<'g, 'ctx> Generator<'g, 'ctx> {
                     self.builder.build_int_sub(lhs, rhs, "sub").into()
                 } else {
                     let overflow_fn = self.get_overflow_fn(ast::BinaryOp::Sub, ty, lhs.get_type());
-                    let result =
-                        self.gen_call_overflow_fn(state, overflow_fn, lhs, rhs, span, "subtract");
+                    let result = self.gen_call_overflow_fn(state, overflow_fn, lhs, rhs, span, "subtract");
                     result.into()
                 }
             }
@@ -389,8 +347,7 @@ impl<'g, 'ctx> Generator<'g, 'ctx> {
                     self.builder.build_int_mul(lhs, rhs, "imul").into()
                 } else {
                     let overflow_fn = self.get_overflow_fn(ast::BinaryOp::Mul, ty, lhs.get_type());
-                    let result =
-                        self.gen_call_overflow_fn(state, overflow_fn, lhs, rhs, span, "multiply");
+                    let result = self.gen_call_overflow_fn(state, overflow_fn, lhs, rhs, span, "multiply");
                     result.into()
                 }
             }
@@ -460,31 +417,19 @@ impl<'g, 'ctx> Generator<'g, 'ctx> {
         }
     }
 
-    pub(super) fn gen_and(
-        &mut self,
-        lhs: BasicValueEnum<'ctx>,
-        rhs: BasicValueEnum<'ctx>,
-    ) -> BasicValueEnum<'ctx> {
+    pub(super) fn gen_and(&mut self, lhs: BasicValueEnum<'ctx>, rhs: BasicValueEnum<'ctx>) -> BasicValueEnum<'ctx> {
         self.builder
             .build_and(lhs.into_int_value(), rhs.into_int_value(), "iand")
             .into()
     }
 
-    pub(super) fn gen_or(
-        &mut self,
-        lhs: BasicValueEnum<'ctx>,
-        rhs: BasicValueEnum<'ctx>,
-    ) -> BasicValueEnum<'ctx> {
+    pub(super) fn gen_or(&mut self, lhs: BasicValueEnum<'ctx>, rhs: BasicValueEnum<'ctx>) -> BasicValueEnum<'ctx> {
         self.builder
             .build_or(lhs.into_int_value(), rhs.into_int_value(), "ior")
             .into()
     }
 
-    pub(super) fn gen_shl(
-        &mut self,
-        lhs: BasicValueEnum<'ctx>,
-        rhs: BasicValueEnum<'ctx>,
-    ) -> BasicValueEnum<'ctx> {
+    pub(super) fn gen_shl(&mut self, lhs: BasicValueEnum<'ctx>, rhs: BasicValueEnum<'ctx>) -> BasicValueEnum<'ctx> {
         self.builder
             .build_left_shift(lhs.into_int_value(), rhs.into_int_value(), "ishl")
             .into()
@@ -497,20 +442,11 @@ impl<'g, 'ctx> Generator<'g, 'ctx> {
         ty: Type,
     ) -> BasicValueEnum<'ctx> {
         self.builder
-            .build_right_shift(
-                lhs.into_int_value(),
-                rhs.into_int_value(),
-                ty.is_signed_int(),
-                "ishr",
-            )
+            .build_right_shift(lhs.into_int_value(), rhs.into_int_value(), ty.is_signed_int(), "ishr")
             .into()
     }
 
-    pub(super) fn gen_xor(
-        &mut self,
-        lhs: BasicValueEnum<'ctx>,
-        rhs: BasicValueEnum<'ctx>,
-    ) -> BasicValueEnum<'ctx> {
+    pub(super) fn gen_xor(&mut self, lhs: BasicValueEnum<'ctx>, rhs: BasicValueEnum<'ctx>) -> BasicValueEnum<'ctx> {
         self.builder
             .build_xor(lhs.into_int_value(), rhs.into_int_value(), "ixor")
             .into()
@@ -522,13 +458,11 @@ impl<'g, 'ctx> Generator<'g, 'ctx> {
         ty: Type,
         operand_type: IntType<'ctx>,
     ) -> FunctionValue<'ctx> {
-        let overflow_fn_return_type = self.context.struct_type(
-            &[operand_type.into(), self.context.bool_type().into()],
-            false,
-        );
+        let overflow_fn_return_type = self
+            .context
+            .struct_type(&[operand_type.into(), self.context.bool_type().into()], false);
 
-        let overflow_fn_type =
-            overflow_fn_return_type.fn_type(&[operand_type.into(), operand_type.into()], false);
+        let overflow_fn_type = overflow_fn_return_type.fn_type(&[operand_type.into(), operand_type.into()], false);
 
         let llvm_op = format!(
             "{}{}",
@@ -573,11 +507,7 @@ impl<'g, 'ctx> Generator<'g, 'ctx> {
 }
 
 impl<'g, 'ctx> Codegen<'g, 'ctx> for hir::Ref {
-    fn codegen(
-        &self,
-        generator: &mut Generator<'g, 'ctx>,
-        state: &mut FunctionState<'ctx>,
-    ) -> BasicValueEnum<'ctx> {
+    fn codegen(&self, generator: &mut Generator<'g, 'ctx>, state: &mut FunctionState<'ctx>) -> BasicValueEnum<'ctx> {
         let value = self.value.codegen(generator, state);
 
         match value.as_instruction_value() {
@@ -596,11 +526,7 @@ impl<'g, 'ctx> Codegen<'g, 'ctx> for hir::Ref {
 }
 
 impl<'g, 'ctx> Codegen<'g, 'ctx> for hir::Offset {
-    fn codegen(
-        &self,
-        generator: &mut Generator<'g, 'ctx>,
-        state: &mut FunctionState<'ctx>,
-    ) -> BasicValueEnum<'ctx> {
+    fn codegen(&self, generator: &mut Generator<'g, 'ctx>, state: &mut FunctionState<'ctx>) -> BasicValueEnum<'ctx> {
         let value = self.value.codegen(generator, state);
         let index = self.index.codegen(generator, state).into_int_value();
 
@@ -632,30 +558,18 @@ impl<'g, 'ctx> Codegen<'g, 'ctx> for hir::Offset {
 
         let ptr_offset = match &ty {
             Type::Array(..) => unsafe {
-                generator.builder.build_in_bounds_gep(
-                    ptr,
-                    &[index.get_type().const_zero(), index],
-                    "offset",
-                )
+                generator
+                    .builder
+                    .build_in_bounds_gep(ptr, &[index.get_type().const_zero(), index], "offset")
             },
             Type::Pointer(inner, _) => match inner.as_ref() {
                 Type::Array(..) => unsafe {
-                    generator.builder.build_in_bounds_gep(
-                        ptr,
-                        &[index.get_type().const_zero(), index],
-                        "offset",
-                    )
-                },
-                Type::Slice(..) => unsafe {
                     generator
                         .builder
-                        .build_in_bounds_gep(ptr, &[index], "offset")
+                        .build_in_bounds_gep(ptr, &[index.get_type().const_zero(), index], "offset")
                 },
-                _ => unsafe {
-                    generator
-                        .builder
-                        .build_in_bounds_gep(ptr, &[index], "offset")
-                },
+                Type::Slice(..) => unsafe { generator.builder.build_in_bounds_gep(ptr, &[index], "offset") },
+                _ => unsafe { generator.builder.build_in_bounds_gep(ptr, &[index], "offset") },
             },
             ty => unreachable!("{}", ty),
         };

--- a/src/backend/llvm/codegen_control.rs
+++ b/src/backend/llvm/codegen_control.rs
@@ -3,11 +3,7 @@ use crate::hir;
 use inkwell::values::BasicValueEnum;
 
 impl<'g, 'ctx> Codegen<'g, 'ctx> for hir::Control {
-    fn codegen(
-        &self,
-        generator: &mut Generator<'g, 'ctx>,
-        state: &mut FunctionState<'ctx>,
-    ) -> BasicValueEnum<'ctx> {
+    fn codegen(&self, generator: &mut Generator<'g, 'ctx>, state: &mut FunctionState<'ctx>) -> BasicValueEnum<'ctx> {
         match self {
             hir::Control::If(x) => x.codegen(generator, state),
             hir::Control::While(x) => x.codegen(generator, state),
@@ -27,25 +23,17 @@ impl<'g, 'ctx> Codegen<'g, 'ctx> for hir::Control {
 }
 
 impl<'g, 'ctx> Codegen<'g, 'ctx> for hir::If {
-    fn codegen(
-        &self,
-        generator: &mut Generator<'g, 'ctx>,
-        state: &mut FunctionState<'ctx>,
-    ) -> BasicValueEnum<'ctx> {
+    fn codegen(&self, generator: &mut Generator<'g, 'ctx>, state: &mut FunctionState<'ctx>) -> BasicValueEnum<'ctx> {
         generator.gen_conditional(
             state,
             |generator: &mut Generator<'g, 'ctx>, state: &mut FunctionState<'ctx>| {
                 self.condition.codegen(generator, state).into_int_value()
             },
-            |generator: &mut Generator<'g, 'ctx>, state: &mut FunctionState<'ctx>| {
-                self.then.codegen(generator, state)
-            },
+            |generator: &mut Generator<'g, 'ctx>, state: &mut FunctionState<'ctx>| self.then.codegen(generator, state),
             match &self.otherwise {
-                Some(otherwise) => Some(
-                    |generator: &mut Generator<'g, 'ctx>, state: &mut FunctionState<'ctx>| {
-                        otherwise.codegen(generator, state)
-                    },
-                ),
+                Some(otherwise) => Some(|generator: &mut Generator<'g, 'ctx>, state: &mut FunctionState<'ctx>| {
+                    otherwise.codegen(generator, state)
+                }),
                 _ => None,
             },
         )
@@ -53,11 +41,7 @@ impl<'g, 'ctx> Codegen<'g, 'ctx> for hir::If {
 }
 
 impl<'g, 'ctx> Codegen<'g, 'ctx> for hir::While {
-    fn codegen(
-        &self,
-        generator: &mut Generator<'g, 'ctx>,
-        state: &mut FunctionState<'ctx>,
-    ) -> BasicValueEnum<'ctx> {
+    fn codegen(&self, generator: &mut Generator<'g, 'ctx>, state: &mut FunctionState<'ctx>) -> BasicValueEnum<'ctx> {
         let loop_head = generator.append_basic_block(state, "loop_head");
         let loop_body = generator.append_basic_block(state, "loop_body");
         let loop_exit = generator.append_basic_block(state, "loop_exit");
@@ -93,11 +77,7 @@ impl<'g, 'ctx> Codegen<'g, 'ctx> for hir::While {
 }
 
 impl<'g, 'ctx> Codegen<'g, 'ctx> for hir::Return {
-    fn codegen(
-        &self,
-        generator: &mut Generator<'g, 'ctx>,
-        state: &mut FunctionState<'ctx>,
-    ) -> BasicValueEnum<'ctx> {
+    fn codegen(&self, generator: &mut Generator<'g, 'ctx>, state: &mut FunctionState<'ctx>) -> BasicValueEnum<'ctx> {
         let value = self.value.codegen(generator, state);
         generator.gen_return(state, Some(value));
         generator.unit_value()

--- a/src/backend/llvm/conditional.rs
+++ b/src/backend/llvm/conditional.rs
@@ -41,8 +41,7 @@ impl<'g, 'ctx> Generator<'g, 'ctx> {
             if merge_block.is_none() {
                 merge_block = Some(self.append_basic_block(state, "if_merge"));
             }
-            self.builder
-                .build_unconditional_branch(merge_block.unwrap());
+            self.builder.build_unconditional_branch(merge_block.unwrap());
         }
 
         let then_block = self.current_block();
@@ -65,25 +64,20 @@ impl<'g, 'ctx> Generator<'g, 'ctx> {
             if merge_block.is_none() {
                 merge_block = Some(self.append_basic_block(state, "if_merge"));
             }
-            self.builder
-                .build_unconditional_branch(merge_block.unwrap());
+            self.builder.build_unconditional_branch(merge_block.unwrap());
             if let Some(merge_block) = merge_block {
                 self.start_block(state, merge_block);
             }
 
             let phi = self.builder.build_phi(then_type, "if_result");
-            phi.add_incoming(&[
-                (&then_value, then_block),
-                (&otherwise_value, otherwise_block),
-            ]);
+            phi.add_incoming(&[(&then_value, then_block), (&otherwise_value, otherwise_block)]);
             phi.as_basic_value()
         } else {
             if !otherwise_has_terminator {
                 if merge_block.is_none() {
                     merge_block = Some(self.append_basic_block(state, "if_merge"));
                 }
-                self.builder
-                    .build_unconditional_branch(merge_block.unwrap());
+                self.builder.build_unconditional_branch(merge_block.unwrap());
             }
 
             if let Some(merge_block) = merge_block {

--- a/src/backend/llvm/function.rs
+++ b/src/backend/llvm/function.rs
@@ -110,11 +110,11 @@ impl<'g, 'ctx> Generator<'g, 'ctx> {
 
                         function_value
                     }
-                    hir::FunctionKind::Extern { lib, .. } => {
+                    hir::FunctionKind::Extern { lib, dylib } => {
                         match self.extern_functions.get(&function.qualified_name) {
                             Some(function) => *function,
                             None => {
-                                if let Some(lib) = lib {
+                                if let Some(lib) = lib.as_ref().or(dylib.as_ref()) {
                                     self.extern_libraries.insert(lib.clone());
                                 }
 

--- a/src/backend/llvm/function.rs
+++ b/src/backend/llvm/function.rs
@@ -110,7 +110,7 @@ impl<'g, 'ctx> Generator<'g, 'ctx> {
 
                         function_value
                     }
-                    hir::FunctionKind::Extern { lib, dylib } => {
+                    hir::FunctionKind::Extern { lib, dylib, link_name } => {
                         match self.extern_functions.get(&function.qualified_name) {
                             Some(function) => *function,
                             None => {
@@ -119,8 +119,7 @@ impl<'g, 'ctx> Generator<'g, 'ctx> {
                                 }
 
                                 let function_type = self.fn_type(&function_type);
-                                let function_value =
-                                    self.get_or_add_function(function.qualified_name, function_type, None);
+                                let function_value = self.get_or_add_function(link_name, function_type, None);
 
                                 self.extern_functions.insert(function.qualified_name, function_value);
 

--- a/src/backend/llvm/intrinsics.rs
+++ b/src/backend/llvm/intrinsics.rs
@@ -23,11 +23,7 @@ impl<'g, 'ctx> Generator<'g, 'ctx> {
         }
     }
 
-    fn get_or_create_intrinsic<F>(
-        &mut self,
-        intrinsic: &hir::Intrinsic,
-        create_fn: F,
-    ) -> FunctionValue<'ctx>
+    fn get_or_create_intrinsic<F>(&mut self, intrinsic: &hir::Intrinsic, create_fn: F) -> FunctionValue<'ctx>
     where
         F: FnOnce(&mut Generator<'g, 'ctx>) -> FunctionValue<'ctx>,
     {

--- a/src/backend/llvm/mod.rs
+++ b/src/backend/llvm/mod.rs
@@ -31,9 +31,7 @@ use execute::Execute;
 use inkwell::{
     context::Context,
     module::Module,
-    targets::{
-        CodeModel, FileType, InitializationConfig, RelocMode, Target, TargetMachine, TargetTriple,
-    },
+    targets::{CodeModel, FileType, InitializationConfig, RelocMode, Target, TargetMachine, TargetTriple},
     OptimizationLevel,
 };
 use path_absolutize::Absolutize;
@@ -62,9 +60,7 @@ pub fn codegen<'w>(workspace: &Workspace, tcx: &TypeCtx, cache: &hir::Cache) -> 
     match &target_metrics.arch {
         Arch::Amd64 | Arch::_386 => Target::initialize_x86(&InitializationConfig::default()),
         Arch::Arm64 => Target::initialize_aarch64(&InitializationConfig::default()),
-        Arch::Wasm32 | Arch::Wasm64 => {
-            Target::initialize_webassembly(&InitializationConfig::default())
-        }
+        Arch::Wasm32 | Arch::Wasm64 => Target::initialize_webassembly(&InitializationConfig::default()),
     }
 
     let triple = TargetTriple::create(target_metrics.target_triplet);
@@ -157,9 +153,7 @@ fn build_executable(
     }
 
     if build_options.codegen_options.emit_llvm_ir() {
-        module
-            .print_to_file(output_path.with_extension("ll"))
-            .unwrap();
+        module.print_to_file(output_path.with_extension("ll")).unwrap();
     }
 
     let object_file = if target_metrics.os == Os::Windows {

--- a/src/backend/llvm/mod.rs
+++ b/src/backend/llvm/mod.rs
@@ -175,7 +175,7 @@ fn build_executable(
     };
 
     time! { build_options.emit_times, "link",
-        link(target_metrics, &output_file, &object_file,&extern_libraries,)
+        link(target_metrics, &output_file, &object_file, &extern_libraries)
     }
 
     let _ = std::fs::remove_file(object_file);

--- a/src/backend/llvm/panic.rs
+++ b/src/backend/llvm/panic.rs
@@ -6,28 +6,17 @@ use inkwell::values::{BasicValue, BasicValueEnum, IntValue};
 
 impl<'g, 'ctx> Generator<'g, 'ctx> {
     #[allow(unused)]
-    pub(super) fn gen_panic_with_message(
-        &mut self,
-        state: &mut FunctionState<'ctx>,
-        msg: impl AsRef<str>,
-        span: Span,
-    ) {
+    pub(super) fn gen_panic_with_message(&mut self, state: &mut FunctionState<'ctx>, msg: impl AsRef<str>, span: Span) {
         let message = self.const_str_slice("", msg.as_ref()).into();
         self.gen_panic(state, message, span)
     }
 
-    pub(super) fn gen_panic(
-        &mut self,
-        state: &mut FunctionState<'ctx>,
-        message: BasicValueEnum<'ctx>,
-        span: Span,
-    ) {
+    pub(super) fn gen_panic(&mut self, state: &mut FunctionState<'ctx>, message: BasicValueEnum<'ctx>, span: Span) {
         let panic_fn = self
             .find_decl_by_name("std.panicking", "default_panic_handler")
             .into_function_value();
 
-        let default_panic_handler_info =
-            self.find_binding_info_by_name("std.panicking", "default_panic_handler");
+        let default_panic_handler_info = self.find_binding_info_by_name("std.panicking", "default_panic_handler");
 
         let panic_type = default_panic_handler_info
             .ty
@@ -41,13 +30,9 @@ impl<'g, 'ctx> Generator<'g, 'ctx> {
             .const_str_slice("panic_file_path", state.module_info.file_path)
             .as_basic_value_enum();
 
-        let line = self
-            .ptr_sized_int_type
-            .const_int(span.start.line as _, false);
+        let line = self.ptr_sized_int_type.const_int(span.start.line as _, false);
 
-        let column = self
-            .ptr_sized_int_type
-            .const_int(span.start.column as _, false);
+        let column = self.ptr_sized_int_type.const_int(span.start.column as _, false);
 
         let panic_info = self.build_struct(
             state,
@@ -57,13 +42,7 @@ impl<'g, 'ctx> Generator<'g, 'ctx> {
 
         let panic_info = self.build_load(panic_info.into());
 
-        self.gen_function_call(
-            state,
-            panic_fn,
-            &panic_type,
-            vec![panic_info],
-            &panic_type.return_type,
-        );
+        self.gen_function_call(state, panic_fn, &panic_type, vec![panic_info], &panic_type.return_type);
 
         self.build_unreachable();
     }

--- a/src/backend/llvm/runtime_check.rs
+++ b/src/backend/llvm/runtime_check.rs
@@ -7,12 +7,7 @@ use inkwell::{
 
 macro_rules! release_guard {
     ($generator: expr) => {{
-        if $generator
-            .workspace
-            .build_options
-            .optimization_level
-            .is_release()
-        {
+        if $generator.workspace.build_options.optimization_level.is_release() {
             return;
         }
     }};
@@ -28,15 +23,10 @@ impl<'g, 'ctx> Generator<'g, 'ctx> {
         release_guard!(self);
 
         const NAME: &str = "__runtime_check_division_by_zero";
-        let condition = self.builder.build_int_compare(
-            IntPredicate::EQ,
-            divisor,
-            divisor.get_type().const_zero(),
-            "",
-        );
-        let message = self
-            .const_str_slice(NAME, "attempt to divide by zero")
-            .into();
+        let condition = self
+            .builder
+            .build_int_compare(IntPredicate::EQ, divisor, divisor.get_type().const_zero(), "");
+        let message = self.const_str_slice(NAME, "attempt to divide by zero").into();
         self.gen_conditional_panic(state, NAME, condition, message, span)
     }
 
@@ -84,26 +74,16 @@ impl<'g, 'ctx> Generator<'g, 'ctx> {
         const NAME: &str = "__runtime_check_index_out_of_bounds";
 
         let message = self
-            .const_str_slice(
-                &NAME,
-                "index out of bounds: the len is (len) but the index is (index)",
-            )
+            .const_str_slice(&NAME, "index out of bounds: the len is (len) but the index is (index)")
             .into();
 
-        let is_lower_than_zero = self.builder.build_int_compare(
-            IntPredicate::ULT,
-            index,
-            index.get_type().const_zero(),
-            "",
-        );
+        let is_lower_than_zero =
+            self.builder
+                .build_int_compare(IntPredicate::ULT, index, index.get_type().const_zero(), "");
 
-        let is_larger_than_len = self
-            .builder
-            .build_int_compare(IntPredicate::UGE, index, len, "");
+        let is_larger_than_len = self.builder.build_int_compare(IntPredicate::UGE, index, len, "");
 
-        let condition = self
-            .builder
-            .build_or(is_lower_than_zero, is_larger_than_len, "");
+        let condition = self.builder.build_or(is_lower_than_zero, is_larger_than_len, "");
 
         self.gen_conditional_panic(state, &NAME, condition, message, span);
     }
@@ -123,9 +103,7 @@ impl<'g, 'ctx> Generator<'g, 'ctx> {
             .const_str_slice(&NAME, "slice index starts at (start) but ends at (end)")
             .into();
 
-        let condition = self
-            .builder
-            .build_int_compare(IntPredicate::ULT, high, low, "");
+        let condition = self.builder.build_int_compare(IntPredicate::ULT, high, low, "");
 
         self.gen_conditional_panic(state, &NAME, condition, message, span);
     }
@@ -153,9 +131,7 @@ impl<'g, 'ctx> Generator<'g, 'ctx> {
             self.builder
                 .build_int_compare(IntPredicate::ULT, low, low.get_type().const_zero(), "");
 
-        let is_high_larger_than_len =
-            self.builder
-                .build_int_compare(IntPredicate::UGT, high, len, "");
+        let is_high_larger_than_len = self.builder.build_int_compare(IntPredicate::UGT, high, len, "");
 
         let condition = self
             .builder

--- a/src/backend/llvm/start.rs
+++ b/src/backend/llvm/start.rs
@@ -119,8 +119,7 @@ impl<'g, 'ctx> Generator<'g, 'ctx> {
         // TODO: if this is DLL Main, return 1 instead of 0
 
         if self.current_block().get_terminator().is_none() {
-            self.builder
-                .build_return(Some(&self.context.i32_type().const_zero()));
+            self.builder.build_return(Some(&self.context.i32_type().const_zero()));
         }
 
         self.start_block(&mut state, decl_block);

--- a/src/backend/llvm/traits.rs
+++ b/src/backend/llvm/traits.rs
@@ -18,10 +18,7 @@ impl<'ctx> IsALoadInst for BasicValueEnum<'ctx> {
 impl<'ctx> IsALoadInst for AnyValueEnum<'ctx> {
     fn is_a_load_inst(&self) -> bool {
         if self.is_instruction_value() {
-            matches!(
-                self.into_instruction_value().get_opcode(),
-                InstructionOpcode::Load
-            )
+            matches!(self.into_instruction_value().get_opcode(), InstructionOpcode::Load)
         } else {
             false
         }

--- a/src/backend/llvm/ty.rs
+++ b/src/backend/llvm/ty.rs
@@ -117,7 +117,7 @@ impl<'g, 'ctx> Generator<'g, 'ctx> {
 
         let ret = f.return_type.llvm_type(self);
 
-        ret.fn_type(&params, f.varargs.is_some())
+        ret.fn_type(&params, f.is_variadic())
     }
 
     pub(super) fn get_abi_compliant_fn(&mut self, f: &FunctionType) -> AbiFunction<'ctx> {

--- a/src/backend/llvm/ty.rs
+++ b/src/backend/llvm/ty.rs
@@ -104,10 +104,7 @@ impl<'g, 'ctx> Generator<'g, 'ctx> {
         self.context
             .struct_type(
                 &[
-                    element_ty
-                        .llvm_type(self)
-                        .ptr_type(AddressSpace::Generic)
-                        .into(),
+                    element_ty.llvm_type(self).ptr_type(AddressSpace::Generic).into(),
                     self.ptr_sized_int_type.into(),
                 ],
                 false,
@@ -116,11 +113,7 @@ impl<'g, 'ctx> Generator<'g, 'ctx> {
     }
 
     pub(super) fn fn_type(&mut self, f: &FunctionType) -> inkwell::types::FunctionType<'ctx> {
-        let params: Vec<BasicMetadataTypeEnum> = f
-            .params
-            .iter()
-            .map(|p| p.ty.llvm_type(self).into())
-            .collect();
+        let params: Vec<BasicMetadataTypeEnum> = f.params.iter().map(|p| p.ty.llvm_type(self).into()).collect();
 
         let ret = f.return_type.llvm_type(self);
 
@@ -133,18 +126,12 @@ impl<'g, 'ctx> Generator<'g, 'ctx> {
         abi::get_abi_compliant_fn(self.context, &self.target_metrics, fn_type)
     }
 
-    pub(super) fn abi_compliant_fn_type(
-        &mut self,
-        f: &FunctionType,
-    ) -> inkwell::types::FunctionType<'ctx> {
+    pub(super) fn abi_compliant_fn_type(&mut self, f: &FunctionType) -> inkwell::types::FunctionType<'ctx> {
         let abi_compliant_fn_ty = self.get_abi_compliant_fn(f);
         self.abi_fn_to_type(&abi_compliant_fn_ty)
     }
 
-    pub(super) fn abi_fn_to_type(
-        &mut self,
-        abi_fn: &AbiFunction<'ctx>,
-    ) -> inkwell::types::FunctionType<'ctx> {
+    pub(super) fn abi_fn_to_type(&mut self, abi_fn: &AbiFunction<'ctx>) -> inkwell::types::FunctionType<'ctx> {
         let mut offset = 0;
 
         let ret = match abi_fn.ret.kind {
@@ -196,10 +183,7 @@ impl<'g, 'ctx> Generator<'g, 'ctx> {
         }
     }
 
-    pub(super) fn create_named_struct_type(
-        &mut self,
-        struct_ty: &StructType,
-    ) -> inkwell::types::StructType<'ctx> {
+    pub(super) fn create_named_struct_type(&mut self, struct_ty: &StructType) -> inkwell::types::StructType<'ctx> {
         let struct_type = self.context.opaque_struct_type(&struct_ty.name);
 
         self.types.insert(struct_ty.binding_id, struct_type.into());
@@ -209,13 +193,9 @@ impl<'g, 'ctx> Generator<'g, 'ctx> {
         struct_type
     }
 
-    pub(super) fn create_anonymous_struct_type(
-        &mut self,
-        struct_ty: &StructType,
-    ) -> inkwell::types::StructType<'ctx> {
+    pub(super) fn create_anonymous_struct_type(&mut self, struct_ty: &StructType) -> inkwell::types::StructType<'ctx> {
         let fields = self.create_struct_type_fields(struct_ty);
-        self.context
-            .struct_type(&fields, struct_ty.is_packed_struct())
+        self.context.struct_type(&fields, struct_ty.is_packed_struct())
     }
 
     fn create_struct_type_fields(&mut self, struct_ty: &StructType) -> Vec<BasicTypeEnum<'ctx>> {

--- a/src/backend/llvm/util.rs
+++ b/src/backend/llvm/util.rs
@@ -12,10 +12,7 @@ use crate::{
 use inkwell::{
     basic_block::BasicBlock,
     types::{AnyType, AnyTypeEnum, BasicType, BasicTypeEnum},
-    values::{
-        BasicValue, BasicValueEnum, GlobalValue, InstructionOpcode, IntValue, PointerValue,
-        StructValue,
-    },
+    values::{BasicValue, BasicValueEnum, GlobalValue, InstructionOpcode, IntValue, PointerValue, StructValue},
     AddressSpace, IntPredicate,
 };
 use std::mem;
@@ -38,11 +35,7 @@ impl<'g, 'ctx> Generator<'g, 'ctx> {
         self.builder.build_global_string_ptr(value, name)
     }
 
-    pub(super) fn const_str_slice(
-        &mut self,
-        name: &str,
-        value: impl Into<Ustr>,
-    ) -> StructValue<'ctx> {
+    pub(super) fn const_str_slice(&mut self, name: &str, value: impl Into<Ustr>) -> StructValue<'ctx> {
         let value = value.into();
         let cached_str = self.static_strs.get(&value).map(|v| *v);
 
@@ -53,11 +46,7 @@ impl<'g, 'ctx> Generator<'g, 'ctx> {
     }
 
     #[inline]
-    pub(super) fn const_slice(
-        &mut self,
-        ptr: PointerValue<'ctx>,
-        len: IntValue<'ctx>,
-    ) -> StructValue<'ctx> {
+    pub(super) fn const_slice(&mut self, ptr: PointerValue<'ctx>, len: IntValue<'ctx>) -> StructValue<'ctx> {
         self.const_struct(&[ptr.as_basic_value_enum(), len.as_basic_value_enum()])
     }
 
@@ -81,11 +70,8 @@ impl<'g, 'ctx> Generator<'g, 'ctx> {
         );
 
         let data = unsafe {
-            self.builder.build_in_bounds_gep(
-                sliced_value_ptr.into_pointer_value(),
-                &[low],
-                "slice_low_addr",
-            )
+            self.builder
+                .build_in_bounds_gep(sliced_value_ptr.into_pointer_value(), &[low], "slice_low_addr")
         };
 
         let data_ptr = self.builder.build_struct_gep(ptr, 0, "slice_data").unwrap();
@@ -93,11 +79,9 @@ impl<'g, 'ctx> Generator<'g, 'ctx> {
         self.build_store(data_ptr, data.into());
 
         let slice_len = self.builder.build_int_sub(high, low, "get_slice_len");
-        let slice_len = self.builder.build_int_cast(
-            slice_len,
-            self.ptr_sized_int_type,
-            "cast_slice_len_to_int",
-        );
+        let slice_len = self
+            .builder
+            .build_int_cast(slice_len, self.ptr_sized_int_type, "cast_slice_len_to_int");
 
         let len_ptr = self.builder.build_struct_gep(ptr, 1, "slice_len").unwrap();
 
@@ -108,11 +92,7 @@ impl<'g, 'ctx> Generator<'g, 'ctx> {
         self.builder.get_insert_block().unwrap()
     }
 
-    pub(super) fn append_basic_block(
-        &self,
-        state: &FunctionState<'ctx>,
-        name: &str,
-    ) -> BasicBlock<'ctx> {
+    pub(super) fn append_basic_block(&self, state: &FunctionState<'ctx>, name: &str) -> BasicBlock<'ctx> {
         self.context.append_basic_block(state.function, name)
     }
 
@@ -155,11 +135,7 @@ impl<'g, 'ctx> Generator<'g, 'ctx> {
             }
         }
 
-        let name = self
-            .workspace
-            .binding_infos
-            .get(id)
-            .map_or(ustr(""), |b| b.name);
+        let name = self.workspace.binding_infos.get(id).map_or(ustr(""), |b| b.name);
 
         self.build_alloca_inner(state, llvm_type, &name)
     }
@@ -182,10 +158,7 @@ impl<'g, 'ctx> Generator<'g, 'ctx> {
         let ptr = self.builder.build_alloca(llvm_type, &name);
 
         let align = align_of(llvm_type, self.target_metrics.word_size);
-        ptr.as_instruction_value()
-            .unwrap()
-            .set_alignment(align as _)
-            .unwrap();
+        ptr.as_instruction_value().unwrap().set_alignment(align as _).unwrap();
 
         self.builder.position_at_end(state.current_block);
 
@@ -209,10 +182,7 @@ impl<'g, 'ctx> Generator<'g, 'ctx> {
         match value.get_type() {
             BasicTypeEnum::PointerType(ptr_type) if ptr_type.get_element_type().is_array_type() => {
                 let element_type = ptr_type.get_element_type();
-                let size = size_of(
-                    element_type.try_into().unwrap(),
-                    self.target_metrics.word_size,
-                );
+                let size = size_of(element_type.try_into().unwrap(), self.target_metrics.word_size);
                 let size_value = self.ptr_sized_int_type.const_int(size as _, true);
                 self.build_copy_nonoverlapping(value.into_pointer_value(), ptr, size_value);
             }
@@ -234,21 +204,11 @@ impl<'g, 'ctx> Generator<'g, 'ctx> {
     }
 
     #[allow(unused)]
-    pub(super) fn build_memset(
-        &mut self,
-        ptr: PointerValue<'ctx>,
-        ty: &TypeId,
-        value: IntValue<'ctx>,
-    ) {
+    pub(super) fn build_memset(&mut self, ptr: PointerValue<'ctx>, ty: &TypeId, value: IntValue<'ctx>) {
         let ty = ty.llvm_type(self);
         let bytes_to_set = ty.size_of().unwrap();
         self.builder
-            .build_memset(
-                ptr,
-                self.target_metrics.word_size as u32,
-                value,
-                bytes_to_set,
-            )
+            .build_memset(ptr, self.target_metrics.word_size as u32, value, bytes_to_set)
             .unwrap();
     }
 
@@ -264,10 +224,7 @@ impl<'g, 'ctx> Generator<'g, 'ctx> {
 
         let ptr = self.local_with_alloca(state, BindingId::unknown(), value);
 
-        ptr.as_instruction_value()
-            .unwrap()
-            .set_alignment(align)
-            .unwrap();
+        ptr.as_instruction_value().unwrap().set_alignment(align).unwrap();
 
         ptr
     }
@@ -281,17 +238,11 @@ impl<'g, 'ctx> Generator<'g, 'ctx> {
     ) {
         let raw_pointer_type = self.raw_pointer_type();
 
-        let src_ptr = self
-            .builder
-            .build_pointer_cast(src_ptr, raw_pointer_type, "");
+        let src_ptr = self.builder.build_pointer_cast(src_ptr, raw_pointer_type, "");
 
-        let dst_ptr = self
-            .builder
-            .build_pointer_cast(dst_ptr, raw_pointer_type, "");
+        let dst_ptr = self.builder.build_pointer_cast(dst_ptr, raw_pointer_type, "");
 
-        let size = self
-            .builder
-            .build_int_cast(size, self.ptr_sized_int_type, "");
+        let size = self.builder.build_int_cast(size, self.ptr_sized_int_type, "");
 
         self.builder
             .build_memmove(
@@ -312,17 +263,11 @@ impl<'g, 'ctx> Generator<'g, 'ctx> {
     ) {
         let raw_pointer_type = self.raw_pointer_type();
 
-        let src_ptr = self
-            .builder
-            .build_pointer_cast(src_ptr, raw_pointer_type, "");
+        let src_ptr = self.builder.build_pointer_cast(src_ptr, raw_pointer_type, "");
 
-        let dst_ptr = self
-            .builder
-            .build_pointer_cast(dst_ptr, raw_pointer_type, "");
+        let dst_ptr = self.builder.build_pointer_cast(dst_ptr, raw_pointer_type, "");
 
-        let size = self
-            .builder
-            .build_int_cast(size, self.ptr_sized_int_type, "");
+        let size = self.builder.build_int_cast(size, self.ptr_sized_int_type, "");
 
         self.builder
             .build_memcpy(
@@ -359,11 +304,7 @@ impl<'g, 'ctx> Generator<'g, 'ctx> {
         // println!("dst_type => {:#?}", dst_type);
 
         if value.is_a_load_inst() {
-            let inst_align = value
-                .as_instruction_value()
-                .unwrap()
-                .get_alignment()
-                .unwrap();
+            let inst_align = value.as_instruction_value().unwrap().get_alignment().unwrap();
             src_align = src_align.min(inst_align as usize);
         }
 
@@ -380,11 +321,7 @@ impl<'g, 'ctx> Generator<'g, 'ctx> {
 
             (IntType(i), _) if i.get_bit_width() == 1 => self
                 .builder
-                .build_int_z_extend_or_bit_cast(
-                    value.into_int_value(),
-                    dst_type.into_int_type(),
-                    "",
-                )
+                .build_int_z_extend_or_bit_cast(value.into_int_value(), dst_type.into_int_type(), "")
                 .into(),
 
             (PointerType(_), PointerType(_)) => self
@@ -403,8 +340,7 @@ impl<'g, 'ctx> Generator<'g, 'ctx> {
                 .into(),
 
             (src_type, dst_type)
-                if mem::discriminant(&src_type) == mem::discriminant(&dst_type)
-                    && !src_type.is_aggregate_type() =>
+                if mem::discriminant(&src_type) == mem::discriminant(&dst_type) && !src_type.is_aggregate_type() =>
             {
                 self.builder.build_bitcast(value, dst_type, "")
             }
@@ -425,8 +361,7 @@ impl<'g, 'ctx> Generator<'g, 'ctx> {
                                     .as_instruction_value()
                                     .unwrap_or_else(|| panic!("{:#?}", value_ptr));
 
-                                src_align =
-                                    value_inst.get_alignment().unwrap().max(dst_align as _) as _;
+                                src_align = value_inst.get_alignment().unwrap().max(dst_align as _) as _;
 
                                 value_inst.set_alignment(src_align as _).unwrap();
                             }
@@ -444,11 +379,9 @@ impl<'g, 'ctx> Generator<'g, 'ctx> {
                 if value.is_a_load_inst() && src_size >= dst_size && src_align >= dst_align {
                     let value_ptr = self.get_operand(value).into_pointer_value();
 
-                    let ptr = self.builder.build_pointer_cast(
-                        value_ptr,
-                        dst_type.ptr_type(AddressSpace::Generic),
-                        "",
-                    );
+                    let ptr = self
+                        .builder
+                        .build_pointer_cast(value_ptr, dst_type.ptr_type(AddressSpace::Generic), "");
 
                     self.build_load(ptr.into())
                 } else {
@@ -461,19 +394,15 @@ impl<'g, 'ctx> Generator<'g, 'ctx> {
                         inst.set_alignment(max_align as _).unwrap();
                     }
 
-                    let ptr = self.builder.build_pointer_cast(
-                        ptr,
-                        src_type.ptr_type(AddressSpace::Generic),
-                        "",
-                    );
+                    let ptr = self
+                        .builder
+                        .build_pointer_cast(ptr, src_type.ptr_type(AddressSpace::Generic), "");
 
                     self.build_store(ptr, value);
 
-                    let ptr = self.builder.build_pointer_cast(
-                        ptr,
-                        dst_type.ptr_type(AddressSpace::Generic),
-                        "",
-                    );
+                    let ptr = self
+                        .builder
+                        .build_pointer_cast(ptr, dst_type.ptr_type(AddressSpace::Generic), "");
 
                     self.build_load(ptr.into())
                 }
@@ -489,19 +418,12 @@ impl<'g, 'ctx> Generator<'g, 'ctx> {
     ) -> BasicValueEnum<'ctx> {
         match value.as_instruction_value() {
             Some(instruction) if instruction.get_opcode() == InstructionOpcode::Load => {
-                let pointer = instruction
-                    .get_operand(0)
-                    .unwrap()
-                    .left()
-                    .unwrap()
-                    .into_pointer_value();
+                let pointer = instruction.get_operand(0).unwrap().left().unwrap().into_pointer_value();
 
                 let gep = self
                     .builder
                     .build_struct_gep(pointer, field_index, field_name)
-                    .unwrap_or_else(|_| {
-                        panic!("{pointer:#?} . {field_name} (index: {field_index})")
-                    });
+                    .unwrap_or_else(|_| panic!("{pointer:#?} . {field_name} (index: {field_index})"));
 
                 self.builder.build_load(gep, field_name)
             }

--- a/src/check/attrs.rs
+++ b/src/check/attrs.rs
@@ -28,19 +28,20 @@ impl<'s> CheckSess<'s> {
                 Some(value) => {
                     let node = value.check(self, env, Some(expected_type))?;
 
-                    node.ty()
-                        .unify(&expected_type, &mut self.tcx)
-                        .or_report_err(&self.tcx, expected_type, None, node.ty(), node.span())?;
+                    node.ty().unify(&expected_type, &mut self.tcx).or_report_err(
+                        &self.tcx,
+                        expected_type,
+                        None,
+                        node.ty(),
+                        node.span(),
+                    )?;
 
                     let node_span = node.span();
 
                     node.into_const_value().ok_or_else(|| {
                         Diagnostic::error()
                             .with_message("attribute value must be compile-time known")
-                            .with_label(Label::primary(
-                                node_span,
-                                "value is not compile-time known",
-                            ))
+                            .with_label(Label::primary(node_span, "value is not compile-time known"))
                     })?
                 }
                 None => {

--- a/src/check/attrs.rs
+++ b/src/check/attrs.rs
@@ -82,7 +82,7 @@ impl<'s> CheckSess<'s> {
     fn get_attr_expected_type(&self, kind: AttrKind) -> TypeId {
         match kind {
             AttrKind::Intrinsic | AttrKind::Entry => self.tcx.common_types.unit,
-            AttrKind::Lib | AttrKind::Dylib => self.tcx.common_types.str,
+            AttrKind::Lib | AttrKind::Dylib | AttrKind::LinkName => self.tcx.common_types.str,
         }
     }
 
@@ -132,7 +132,7 @@ impl<'s> CheckSess<'s> {
                         _ => return err(),
                     }
                 }
-                AttrKind::Lib | AttrKind::Dylib => match &binding.kind {
+                AttrKind::Lib | AttrKind::Dylib | AttrKind::LinkName => match &binding.kind {
                     ast::BindingKind::ExternFunction { .. } | ast::BindingKind::ExternVariable { .. } => (),
                     _ => {
                         return Err(invalid_attr_use(

--- a/src/check/attrs.rs
+++ b/src/check/attrs.rs
@@ -13,7 +13,6 @@ use crate::{
         const_value::ConstValue,
     },
     infer::{display::OrReportErr, unify::UnifyType},
-    span::Span,
     types::TypeId,
 };
 
@@ -82,6 +81,7 @@ impl<'s> CheckSess<'s> {
     fn get_attr_expected_type(&self, kind: AttrKind) -> TypeId {
         match kind {
             AttrKind::Intrinsic | AttrKind::Entry => self.tcx.common_types.unit,
+            AttrKind::Lib => self.tcx.common_types.str,
         }
     }
 
@@ -131,6 +131,15 @@ impl<'s> CheckSess<'s> {
                         _ => return err(),
                     }
                 }
+                AttrKind::Lib => match &binding.kind {
+                    ast::BindingKind::ExternFunction { .. } | ast::BindingKind::ExternVariable { .. } => (),
+                    _ => {
+                        return Err(invalid_attr_use(
+                            attr,
+                            "can only be used on extern variables and functions",
+                        ))
+                    }
+                },
             }
         }
 

--- a/src/check/const_fold/binary.rs
+++ b/src/check/const_fold/binary.rs
@@ -28,9 +28,7 @@ pub fn binary(
         },
         ast::BinaryOp::Rem => match rhs {
             ConstValue::Int(0) | ConstValue::Uint(0) => Err(SyntaxError::divide_by_zero(span)),
-            _ => lhs
-                .rem(rhs)
-                .ok_or_else(|| int_overflow("taking the remainder of")),
+            _ => lhs.rem(rhs).ok_or_else(|| int_overflow("taking the remainder of")),
         },
         ast::BinaryOp::Eq => Ok(lhs.eq(rhs)),
         ast::BinaryOp::Ne => Ok(lhs.ne(rhs)),
@@ -48,13 +46,7 @@ pub fn binary(
     }
 }
 
-fn int_overflow(
-    action: &str,
-    lhs: &ConstValue,
-    rhs: &ConstValue,
-    span: Span,
-    tcx: &TypeCtx,
-) -> Diagnostic {
+fn int_overflow(action: &str, lhs: &ConstValue, rhs: &ConstValue, span: Span, tcx: &TypeCtx) -> Diagnostic {
     Diagnostic::error()
         .with_message(format!(
             "integer overflowed while {} {} and {} at compile-time",

--- a/src/check/entry.rs
+++ b/src/check/entry.rs
@@ -32,7 +32,7 @@ impl<'s> CheckSess<'s> {
                     // Validate its type is fn() -> ()
                     if !(ty.return_type.is_unit() || ty.return_type.is_never())
                         || !ty.params.is_empty()
-                        || ty.varargs.is_some()
+                        || ty.is_variadic()
                     {
                         return Err(Diagnostic::error()
                             .with_message(format!(

--- a/src/check/mod.rs
+++ b/src/check/mod.rs
@@ -441,6 +441,11 @@ impl Check for ast::Binding {
 
                 let lib = sess.maybe_get_extern_lib_attr(env, &attrs, AttrKind::Lib)?;
                 let dylib = sess.maybe_get_extern_lib_attr(env, &attrs, AttrKind::Dylib)?;
+                let link_name = if let Some(attr) = attrs.get(AttrKind::LinkName) {
+                    *attr.value.as_str().unwrap()
+                } else {
+                    name
+                };
 
                 let function_type_node = sig.check(sess, env, Some(sess.tcx.common_types.anytype))?;
 
@@ -473,6 +478,7 @@ impl Check for ast::Binding {
                         hir::FunctionKind::Extern {
                             lib: lib.clone(),
                             dylib: dylib.or(lib),
+                            link_name,
                         },
                         BindingInfoKind::ExternFunction,
                     )
@@ -521,10 +527,15 @@ impl Check for ast::Binding {
 
                 let lib = sess.maybe_get_extern_lib_attr(env, &attrs, AttrKind::Lib)?;
                 let dylib = sess.maybe_get_extern_lib_attr(env, &attrs, AttrKind::Dylib)?;
+                let link_name = if let Some(attr) = attrs.get(AttrKind::LinkName) {
+                    *attr.value.as_str().unwrap()
+                } else {
+                    name
+                };
 
                 let value = hir::Node::Const(hir::Const {
                     value: ConstValue::ExternVariable(ConstExternVariable {
-                        name,
+                        name: link_name,
                         lib: lib.clone(),
                         dylib: dylib.or(lib),
                         ty,

--- a/src/check/mod.rs
+++ b/src/check/mod.rs
@@ -327,6 +327,8 @@ impl Check for ast::Binding {
     fn check(&self, sess: &mut CheckSess, env: &mut Env, _expected_type: Option<TypeId>) -> CheckResult {
         let attrs = sess.check_attrs(&self.attrs, env)?;
 
+        sess.check_attrs_are_assigned_to_valid_binding(&attrs, self)?;
+
         match &self.kind {
             ast::BindingKind::Orphan {
                 pattern,

--- a/src/common/build_options.rs
+++ b/src/common/build_options.rs
@@ -58,21 +58,20 @@ impl BuildOptions {
     }
 
     pub fn start_function_name(&self) -> Option<&'static str> {
-        self.need_entry_point_function()
-            .then(|| match &self.target_platform {
-                TargetPlatform::Windows386
-                | TargetPlatform::WindowsAmd64
-                | TargetPlatform::Linux386
-                | TargetPlatform::LinuxAmd64
-                | TargetPlatform::LinuxArm64
-                | TargetPlatform::DarwinAmd64
-                | TargetPlatform::DarwinArm64
-                | TargetPlatform::FreeBSD386
-                | TargetPlatform::FreeBSDAmd64
-                | TargetPlatform::EssenceAmd64 => "main",
+        self.need_entry_point_function().then(|| match &self.target_platform {
+            TargetPlatform::Windows386
+            | TargetPlatform::WindowsAmd64
+            | TargetPlatform::Linux386
+            | TargetPlatform::LinuxAmd64
+            | TargetPlatform::LinuxArm64
+            | TargetPlatform::DarwinAmd64
+            | TargetPlatform::DarwinArm64
+            | TargetPlatform::FreeBSD386
+            | TargetPlatform::FreeBSDAmd64
+            | TargetPlatform::EssenceAmd64 => "main",
 
-                p => panic!("unexpected TargetPlatform::{:?}", p),
-            })
+            p => panic!("unexpected TargetPlatform::{:?}", p),
+        })
     }
 }
 

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -18,10 +18,7 @@ pub struct Stopwatch<'s> {
 impl<'s> Stopwatch<'s> {
     #[allow(unused)]
     pub fn new(label: &'s str) -> Self {
-        Self {
-            label,
-            sw: SW::new(),
-        }
+        Self { label, sw: SW::new() }
     }
 
     pub fn start_new(label: &'s str) -> Self {

--- a/src/common/path.rs
+++ b/src/common/path.rs
@@ -35,6 +35,7 @@ pub fn maybe_resolve_relative_path(path: &Path, relative_to: &RelativeTo) -> Opt
     absolute_path.exists().then(|| absolute_path.to_path_buf())
 }
 
+#[allow(unused)]
 pub fn resolve_relative_path(path: &Path, relative_to: &RelativeTo) -> PathBuf {
     get_absolute_path(relative_to, path).to_path_buf()
 }

--- a/src/common/path.rs
+++ b/src/common/path.rs
@@ -13,13 +13,10 @@ pub enum RelativeTo<'a> {
 
 pub fn try_resolve_relative_path<'a>(
     path: &'a Path,
-    relative_to: RelativeTo,
+    relative_to: &RelativeTo,
     span: Option<Span>,
 ) -> DiagnosticResult<PathBuf> {
-    let absolute_path = match relative_to {
-        RelativeTo::Path(relative_to) => path.absolutize_from(relative_to).unwrap(),
-        RelativeTo::Cwd => path.absolutize().unwrap(),
-    };
+    let absolute_path = get_absolute_path(relative_to, path);
 
     if absolute_path.exists() {
         Ok(absolute_path.to_path_buf())
@@ -33,11 +30,18 @@ pub fn try_resolve_relative_path<'a>(
     }
 }
 
-pub fn resolve_relative_path(path: &Path, relative_to: RelativeTo) -> Option<PathBuf> {
-    let absolute_path = match relative_to {
+pub fn maybe_resolve_relative_path(path: &Path, relative_to: &RelativeTo) -> Option<PathBuf> {
+    let absolute_path = get_absolute_path(relative_to, path);
+    absolute_path.exists().then(|| absolute_path.to_path_buf())
+}
+
+pub fn resolve_relative_path(path: &Path, relative_to: &RelativeTo) -> PathBuf {
+    get_absolute_path(relative_to, path).to_path_buf()
+}
+
+fn get_absolute_path<'a>(relative_to: &'a RelativeTo, path: &'a Path) -> std::borrow::Cow<'a, Path> {
+    match relative_to {
         RelativeTo::Path(relative_to) => path.absolutize_from(relative_to).unwrap(),
         RelativeTo::Cwd => path.absolutize().unwrap(),
-    };
-
-    absolute_path.exists().then(|| absolute_path.to_path_buf())
+    }
 }

--- a/src/common/target.rs
+++ b/src/common/target.rs
@@ -43,10 +43,7 @@ pub enum TargetPlatform {
 impl TargetPlatform {
     #[allow(unused)]
     pub fn is_windows(&self) -> bool {
-        matches!(
-            self,
-            TargetPlatform::Windows386 | TargetPlatform::WindowsAmd64
-        )
+        matches!(self, TargetPlatform::Windows386 | TargetPlatform::WindowsAmd64)
     }
 
     #[allow(unused)]
@@ -59,18 +56,12 @@ impl TargetPlatform {
 
     #[allow(unused)]
     pub fn is_darwin(&self) -> bool {
-        matches!(
-            self,
-            TargetPlatform::DarwinAmd64 | TargetPlatform::DarwinArm64
-        )
+        matches!(self, TargetPlatform::DarwinAmd64 | TargetPlatform::DarwinArm64)
     }
 
     #[allow(unused)]
     pub fn is_free_bsd(&self) -> bool {
-        matches!(
-            self,
-            TargetPlatform::FreeBSD386 | TargetPlatform::FreeBSDAmd64
-        )
+        matches!(self, TargetPlatform::FreeBSD386 | TargetPlatform::FreeBSDAmd64)
     }
 
     #[allow(unused)]
@@ -82,9 +73,7 @@ impl TargetPlatform {
     pub fn is_wasm(&self) -> bool {
         matches!(
             self,
-            TargetPlatform::FreestandingWasm32
-                | TargetPlatform::JsWasm32
-                | TargetPlatform::WasiWasm32
+            TargetPlatform::FreestandingWasm32 | TargetPlatform::JsWasm32 | TargetPlatform::WasiWasm32
         )
     }
 
@@ -269,9 +258,7 @@ impl Arch {
     #[allow(unused)]
     pub fn endianness(&self) -> Endianness {
         match self {
-            Arch::Amd64 | Arch::_386 | Arch::Arm64 | Arch::Wasm32 | Arch::Wasm64 => {
-                Endianness::Little
-            }
+            Arch::Amd64 | Arch::_386 | Arch::Arm64 | Arch::Wasm32 | Arch::Wasm64 => Endianness::Little,
         }
     }
 }

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -40,12 +40,7 @@ impl StartWorkspaceResult {
         }
     }
 
-    fn new_typed_with_output(
-        workspace: Workspace,
-        tcx: TypeCtx,
-        cache: hir::Cache,
-        output_file: PathBuf,
-    ) -> Self {
+    fn new_typed_with_output(workspace: Workspace, tcx: TypeCtx, cache: hir::Cache, output_file: PathBuf) -> Self {
         Self {
             workspace,
             tcx: Some(tcx),
@@ -72,10 +67,9 @@ pub fn start_workspace(name: String, build_options: BuildOptions) -> StartWorksp
 
     // Check that root file exists
     if !source_file.exists() {
-        workspace.diagnostics.push(
-            Diagnostic::error()
-                .with_message(format!("file `{}` doesn't exist", source_file.display())),
-        );
+        workspace
+            .diagnostics
+            .push(Diagnostic::error().with_message(format!("file `{}` doesn't exist", source_file.display())));
 
         workspace.emit_diagnostics();
 

--- a/src/error/emitter.rs
+++ b/src/error/emitter.rs
@@ -60,12 +60,8 @@ impl From<Diagnostic> for CodespanDiagnostic {
                 val.labels
                     .into_iter()
                     .map(|l| {
-                        codespan_reporting::diagnostic::Label::new(
-                            l.kind.into(),
-                            l.span.file_id,
-                            l.span.range(),
-                        )
-                        .with_message(l.message)
+                        codespan_reporting::diagnostic::Label::new(l.kind.into(), l.span.file_id, l.span.range())
+                            .with_message(l.message)
                     })
                     .collect(),
             )

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -87,11 +87,7 @@ impl SyntaxError {
             .with_label(Label::primary(span, ""))
     }
 
-    pub fn duplicate_binding(
-        already_defined_span: Span,
-        duplicate_span: Span,
-        name: Ustr,
-    ) -> Diagnostic {
+    pub fn duplicate_binding(already_defined_span: Span, duplicate_span: Span, name: Ustr) -> Diagnostic {
         Diagnostic::error()
             .with_message(format!("duplicate definitions with name `{}`", name))
             .with_label(Label::primary(duplicate_span, "duplicate definition here"))
@@ -101,16 +97,9 @@ impl SyntaxError {
             ))
     }
 
-    pub fn duplicate_struct_field(
-        defined_field_span: Span,
-        field_span: Span,
-        field_name: String,
-    ) -> Diagnostic {
+    pub fn duplicate_struct_field(defined_field_span: Span, field_span: Span, field_name: String) -> Diagnostic {
         Diagnostic::error()
-            .with_message(format!(
-                "struct field `{}` is defined more than once",
-                field_name
-            ))
+            .with_message(format!("struct field `{}` is defined more than once", field_name))
             .with_label(Label::primary(field_span, "field defined more than once"))
             .with_label(Label::secondary(
                 defined_field_span,
@@ -144,22 +133,13 @@ pub struct TypeError;
 impl TypeError {
     pub fn type_is_unsized(ty: String, span: Span) -> Diagnostic {
         Diagnostic::error()
-            .with_message(format!(
-                "the size of type `{}` cannot be known at compile-time",
-                ty
-            ))
-            .with_label(Label::primary(
-                span,
-                "doesn't have a size known at compile-time",
-            ))
+            .with_message(format!("the size of type `{}` cannot be known at compile-time", ty))
+            .with_label(Label::primary(span, "doesn't have a size known at compile-time"))
     }
 
     pub fn binding_is_unsized(name: &str, ty: String, span: Span) -> Diagnostic {
         Diagnostic::error()
-            .with_message(format!(
-                "the size of type `{}` cannot be known at compile-time",
-                ty
-            ))
+            .with_message(format!("the size of type `{}` cannot be known at compile-time", ty))
             .with_label(Label::primary(
                 span,
                 format!("`{}` doesn't have a size known at compile-time", name),
@@ -172,12 +152,7 @@ impl TypeError {
             .with_label(Label::primary(span, ""))
     }
 
-    pub fn tuple_field_out_of_bounds(
-        span: Span,
-        field: &str,
-        ty: String,
-        max: usize,
-    ) -> Diagnostic {
+    pub fn tuple_field_out_of_bounds(span: Span, field: &str, ty: String, max: usize) -> Diagnostic {
         Diagnostic::error()
             .with_message(format!(
                 "no field `{}` on type `{}`, expected index between 0 and {}",
@@ -188,14 +163,8 @@ impl TypeError {
 
     pub fn non_numeric_tuple_field(span: Span, field: &str, ty: String) -> Diagnostic {
         Diagnostic::error()
-            .with_message(format!(
-                "can only access tuple `{}` fields by its indices",
-                ty
-            ))
-            .with_label(Label::primary(
-                span,
-                format!("invalid tuple member `{}`", field),
-            ))
+            .with_message(format!("can only access tuple `{}` fields by its indices", ty))
+            .with_label(Label::primary(span, format!("invalid tuple member `{}`", field)))
     }
 
     pub fn invalid_struct_field(span: Span, field: Ustr, ty: String) -> Diagnostic {

--- a/src/hir/attrs.rs
+++ b/src/hir/attrs.rs
@@ -55,6 +55,7 @@ pub enum AttrKind {
     Intrinsic,
     Entry,
     Lib,
+    Dylib,
 }
 
 impl TryFrom<&str> for AttrKind {
@@ -65,6 +66,7 @@ impl TryFrom<&str> for AttrKind {
             "intrinsic" => Ok(AttrKind::Intrinsic),
             "entry" => Ok(AttrKind::Entry),
             "lib" => Ok(AttrKind::Lib),
+            "dylib" => Ok(AttrKind::Dylib),
             _ => Err(()),
         }
     }
@@ -76,6 +78,7 @@ impl Display for AttrKind {
             AttrKind::Intrinsic => write!(f, "intrinsic"),
             AttrKind::Entry => write!(f, "entry"),
             AttrKind::Lib => write!(f, "lib"),
+            AttrKind::Dylib => write!(f, "dylib"),
         }
     }
 }

--- a/src/hir/attrs.rs
+++ b/src/hir/attrs.rs
@@ -56,6 +56,7 @@ pub enum AttrKind {
     Entry,
     Lib,
     Dylib,
+    LinkName,
 }
 
 impl TryFrom<&str> for AttrKind {
@@ -67,6 +68,7 @@ impl TryFrom<&str> for AttrKind {
             "entry" => Ok(AttrKind::Entry),
             "lib" => Ok(AttrKind::Lib),
             "dylib" => Ok(AttrKind::Dylib),
+            "link_name" => Ok(AttrKind::LinkName),
             _ => Err(()),
         }
     }
@@ -79,6 +81,7 @@ impl Display for AttrKind {
             AttrKind::Entry => write!(f, "entry"),
             AttrKind::Lib => write!(f, "lib"),
             AttrKind::Dylib => write!(f, "dylib"),
+            AttrKind::LinkName => write!(f, "link_name"),
         }
     }
 }

--- a/src/hir/attrs.rs
+++ b/src/hir/attrs.rs
@@ -1,5 +1,8 @@
 use crate::span::Span;
-use std::{collections::HashMap, fmt::Display};
+use std::{
+    collections::{hash_map, HashMap},
+    fmt::Display,
+};
 
 use super::const_value::ConstValue;
 
@@ -23,6 +26,10 @@ impl Attrs {
 
     pub fn has(&self, kind: AttrKind) -> bool {
         self.inner.contains_key(&kind)
+    }
+
+    pub fn iter(&self) -> hash_map::Iter<AttrKind, Attr> {
+        self.inner.iter()
     }
 
     #[allow(unused)]

--- a/src/hir/attrs.rs
+++ b/src/hir/attrs.rs
@@ -54,6 +54,7 @@ pub struct Attr {
 pub enum AttrKind {
     Intrinsic,
     Entry,
+    Lib,
 }
 
 impl TryFrom<&str> for AttrKind {
@@ -63,6 +64,7 @@ impl TryFrom<&str> for AttrKind {
         match value {
             "intrinsic" => Ok(AttrKind::Intrinsic),
             "entry" => Ok(AttrKind::Entry),
+            "lib" => Ok(AttrKind::Lib),
             _ => Err(()),
         }
     }
@@ -73,6 +75,7 @@ impl Display for AttrKind {
         match self {
             AttrKind::Intrinsic => write!(f, "intrinsic"),
             AttrKind::Entry => write!(f, "entry"),
+            AttrKind::Lib => write!(f, "lib"),
         }
     }
 }

--- a/src/hir/attrs.rs
+++ b/src/hir/attrs.rs
@@ -10,9 +10,7 @@ pub struct Attrs {
 
 impl Attrs {
     pub fn new() -> Self {
-        Self {
-            inner: HashMap::new(),
-        }
+        Self { inner: HashMap::new() }
     }
 
     pub fn insert(&mut self, attr: Attr) -> Option<Attr> {

--- a/src/hir/const_value.rs
+++ b/src/hir/const_value.rs
@@ -95,30 +95,16 @@ impl ConstValue {
     pub fn add(&self, other: &ConstValue) -> Option<ConstValue> {
         match (self, other) {
             (ConstValue::Int(v1), ConstValue::Int(v2)) => v1.checked_add(*v2).map(ConstValue::Int),
-            (ConstValue::Uint(v1), ConstValue::Uint(v2)) => {
-                v1.checked_add(*v2).map(ConstValue::Uint)
-            }
+            (ConstValue::Uint(v1), ConstValue::Uint(v2)) => v1.checked_add(*v2).map(ConstValue::Uint),
 
-            (ConstValue::Int(v1), ConstValue::Uint(v2)) => {
-                v1.checked_add(*v2 as i64).map(ConstValue::Int)
-            }
-            (ConstValue::Uint(v1), ConstValue::Int(v2)) => {
-                (*v1 as i64).checked_add(*v2).map(ConstValue::Int)
-            }
+            (ConstValue::Int(v1), ConstValue::Uint(v2)) => v1.checked_add(*v2 as i64).map(ConstValue::Int),
+            (ConstValue::Uint(v1), ConstValue::Int(v2)) => (*v1 as i64).checked_add(*v2).map(ConstValue::Int),
 
-            (ConstValue::Int(v1), ConstValue::Float(v2)) => {
-                Some(ConstValue::Float(*v1 as f64 + *v2))
-            }
-            (ConstValue::Float(v1), ConstValue::Int(v2)) => {
-                Some(ConstValue::Float(*v1 + *v2 as f64))
-            }
+            (ConstValue::Int(v1), ConstValue::Float(v2)) => Some(ConstValue::Float(*v1 as f64 + *v2)),
+            (ConstValue::Float(v1), ConstValue::Int(v2)) => Some(ConstValue::Float(*v1 + *v2 as f64)),
 
-            (ConstValue::Uint(v1), ConstValue::Float(v2)) => {
-                Some(ConstValue::Float(*v1 as f64 + *v2))
-            }
-            (ConstValue::Float(v1), ConstValue::Uint(v2)) => {
-                Some(ConstValue::Float(*v1 + *v2 as f64))
-            }
+            (ConstValue::Uint(v1), ConstValue::Float(v2)) => Some(ConstValue::Float(*v1 as f64 + *v2)),
+            (ConstValue::Float(v1), ConstValue::Uint(v2)) => Some(ConstValue::Float(*v1 + *v2 as f64)),
 
             (ConstValue::Float(v1), ConstValue::Float(v2)) => Some(ConstValue::Float(*v1 + *v2)),
 
@@ -130,30 +116,16 @@ impl ConstValue {
         match (self, other) {
             (ConstValue::Int(v1), ConstValue::Int(v2)) => v1.checked_sub(*v2).map(ConstValue::Int),
 
-            (ConstValue::Uint(v1), ConstValue::Uint(v2)) => {
-                v1.checked_sub(*v2).map(ConstValue::Uint)
-            }
+            (ConstValue::Uint(v1), ConstValue::Uint(v2)) => v1.checked_sub(*v2).map(ConstValue::Uint),
 
-            (ConstValue::Int(v1), ConstValue::Uint(v2)) => {
-                v1.checked_sub(*v2 as i64).map(ConstValue::Int)
-            }
-            (ConstValue::Uint(v1), ConstValue::Int(v2)) => {
-                (*v1 as i64).checked_sub(*v2).map(ConstValue::Int)
-            }
+            (ConstValue::Int(v1), ConstValue::Uint(v2)) => v1.checked_sub(*v2 as i64).map(ConstValue::Int),
+            (ConstValue::Uint(v1), ConstValue::Int(v2)) => (*v1 as i64).checked_sub(*v2).map(ConstValue::Int),
 
-            (ConstValue::Int(v1), ConstValue::Float(v2)) => {
-                Some(ConstValue::Float(*v1 as f64 - *v2))
-            }
-            (ConstValue::Float(v1), ConstValue::Int(v2)) => {
-                Some(ConstValue::Float(*v1 - *v2 as f64))
-            }
+            (ConstValue::Int(v1), ConstValue::Float(v2)) => Some(ConstValue::Float(*v1 as f64 - *v2)),
+            (ConstValue::Float(v1), ConstValue::Int(v2)) => Some(ConstValue::Float(*v1 - *v2 as f64)),
 
-            (ConstValue::Uint(v1), ConstValue::Float(v2)) => {
-                Some(ConstValue::Float(*v1 as f64 - *v2))
-            }
-            (ConstValue::Float(v1), ConstValue::Uint(v2)) => {
-                Some(ConstValue::Float(*v1 - *v2 as f64))
-            }
+            (ConstValue::Uint(v1), ConstValue::Float(v2)) => Some(ConstValue::Float(*v1 as f64 - *v2)),
+            (ConstValue::Float(v1), ConstValue::Uint(v2)) => Some(ConstValue::Float(*v1 - *v2 as f64)),
 
             (ConstValue::Float(v1), ConstValue::Float(v2)) => Some(ConstValue::Float(*v1 - *v2)),
 
@@ -165,30 +137,16 @@ impl ConstValue {
         match (self, other) {
             (ConstValue::Int(v1), ConstValue::Int(v2)) => v1.checked_mul(*v2).map(ConstValue::Int),
 
-            (ConstValue::Uint(v1), ConstValue::Uint(v2)) => {
-                v1.checked_mul(*v2).map(ConstValue::Uint)
-            }
+            (ConstValue::Uint(v1), ConstValue::Uint(v2)) => v1.checked_mul(*v2).map(ConstValue::Uint),
 
-            (ConstValue::Int(v1), ConstValue::Uint(v2)) => {
-                v1.checked_mul(*v2 as i64).map(ConstValue::Int)
-            }
-            (ConstValue::Uint(v1), ConstValue::Int(v2)) => {
-                (*v1 as i64).checked_mul(*v2).map(ConstValue::Int)
-            }
+            (ConstValue::Int(v1), ConstValue::Uint(v2)) => v1.checked_mul(*v2 as i64).map(ConstValue::Int),
+            (ConstValue::Uint(v1), ConstValue::Int(v2)) => (*v1 as i64).checked_mul(*v2).map(ConstValue::Int),
 
-            (ConstValue::Int(v1), ConstValue::Float(v2)) => {
-                Some(ConstValue::Float(*v1 as f64 + *v2))
-            }
-            (ConstValue::Float(v1), ConstValue::Int(v2)) => {
-                Some(ConstValue::Float(*v1 + *v2 as f64))
-            }
+            (ConstValue::Int(v1), ConstValue::Float(v2)) => Some(ConstValue::Float(*v1 as f64 + *v2)),
+            (ConstValue::Float(v1), ConstValue::Int(v2)) => Some(ConstValue::Float(*v1 + *v2 as f64)),
 
-            (ConstValue::Uint(v1), ConstValue::Float(v2)) => {
-                Some(ConstValue::Float(*v1 as f64 + *v2))
-            }
-            (ConstValue::Float(v1), ConstValue::Uint(v2)) => {
-                Some(ConstValue::Float(*v1 + *v2 as f64))
-            }
+            (ConstValue::Uint(v1), ConstValue::Float(v2)) => Some(ConstValue::Float(*v1 as f64 + *v2)),
+            (ConstValue::Float(v1), ConstValue::Uint(v2)) => Some(ConstValue::Float(*v1 + *v2 as f64)),
 
             (ConstValue::Float(v1), ConstValue::Float(v2)) => Some(ConstValue::Float(*v1 + *v2)),
 
@@ -200,31 +158,17 @@ impl ConstValue {
         match (self, other) {
             (ConstValue::Int(v1), ConstValue::Int(v2)) => v1.checked_div(*v2).map(ConstValue::Int),
 
-            (ConstValue::Uint(v1), ConstValue::Uint(v2)) => {
-                v1.checked_div(*v2).map(ConstValue::Uint)
-            }
+            (ConstValue::Uint(v1), ConstValue::Uint(v2)) => v1.checked_div(*v2).map(ConstValue::Uint),
 
-            (ConstValue::Int(v1), ConstValue::Uint(v2)) => {
-                v1.checked_div(*v2 as i64).map(ConstValue::Int)
-            }
+            (ConstValue::Int(v1), ConstValue::Uint(v2)) => v1.checked_div(*v2 as i64).map(ConstValue::Int),
 
-            (ConstValue::Uint(v1), ConstValue::Int(v2)) => {
-                (*v1 as i64).checked_div(*v2).map(ConstValue::Int)
-            }
+            (ConstValue::Uint(v1), ConstValue::Int(v2)) => (*v1 as i64).checked_div(*v2).map(ConstValue::Int),
 
-            (ConstValue::Int(v1), ConstValue::Float(v2)) => {
-                Some(ConstValue::Float(*v1 as f64 / *v2))
-            }
-            (ConstValue::Float(v1), ConstValue::Int(v2)) => {
-                Some(ConstValue::Float(*v1 / *v2 as f64))
-            }
+            (ConstValue::Int(v1), ConstValue::Float(v2)) => Some(ConstValue::Float(*v1 as f64 / *v2)),
+            (ConstValue::Float(v1), ConstValue::Int(v2)) => Some(ConstValue::Float(*v1 / *v2 as f64)),
 
-            (ConstValue::Uint(v1), ConstValue::Float(v2)) => {
-                Some(ConstValue::Float(*v1 as f64 / *v2))
-            }
-            (ConstValue::Float(v1), ConstValue::Uint(v2)) => {
-                Some(ConstValue::Float(*v1 / *v2 as f64))
-            }
+            (ConstValue::Uint(v1), ConstValue::Float(v2)) => Some(ConstValue::Float(*v1 as f64 / *v2)),
+            (ConstValue::Float(v1), ConstValue::Uint(v2)) => Some(ConstValue::Float(*v1 / *v2 as f64)),
 
             (ConstValue::Float(v1), ConstValue::Float(v2)) => Some(ConstValue::Float(*v1 / *v2)),
 
@@ -236,31 +180,17 @@ impl ConstValue {
         match (self, other) {
             (ConstValue::Int(v1), ConstValue::Int(v2)) => v1.checked_rem(*v2).map(ConstValue::Int),
 
-            (ConstValue::Uint(v1), ConstValue::Uint(v2)) => {
-                v1.checked_rem(*v2).map(ConstValue::Uint)
-            }
+            (ConstValue::Uint(v1), ConstValue::Uint(v2)) => v1.checked_rem(*v2).map(ConstValue::Uint),
 
-            (ConstValue::Int(v1), ConstValue::Uint(v2)) => {
-                v1.checked_rem(*v2 as i64).map(ConstValue::Int)
-            }
+            (ConstValue::Int(v1), ConstValue::Uint(v2)) => v1.checked_rem(*v2 as i64).map(ConstValue::Int),
 
-            (ConstValue::Uint(v1), ConstValue::Int(v2)) => {
-                (*v1 as i64).checked_rem(*v2).map(ConstValue::Int)
-            }
+            (ConstValue::Uint(v1), ConstValue::Int(v2)) => (*v1 as i64).checked_rem(*v2).map(ConstValue::Int),
 
-            (ConstValue::Int(v1), ConstValue::Float(v2)) => {
-                Some(ConstValue::Float(*v1 as f64 % *v2))
-            }
-            (ConstValue::Float(v1), ConstValue::Int(v2)) => {
-                Some(ConstValue::Float(*v1 % *v2 as f64))
-            }
+            (ConstValue::Int(v1), ConstValue::Float(v2)) => Some(ConstValue::Float(*v1 as f64 % *v2)),
+            (ConstValue::Float(v1), ConstValue::Int(v2)) => Some(ConstValue::Float(*v1 % *v2 as f64)),
 
-            (ConstValue::Uint(v1), ConstValue::Float(v2)) => {
-                Some(ConstValue::Float(*v1 as f64 % *v2))
-            }
-            (ConstValue::Float(v1), ConstValue::Uint(v2)) => {
-                Some(ConstValue::Float(*v1 % *v2 as f64))
-            }
+            (ConstValue::Uint(v1), ConstValue::Float(v2)) => Some(ConstValue::Float(*v1 as f64 % *v2)),
+            (ConstValue::Float(v1), ConstValue::Uint(v2)) => Some(ConstValue::Float(*v1 % *v2 as f64)),
 
             (ConstValue::Float(v1), ConstValue::Float(v2)) => Some(ConstValue::Float(*v1 % *v2)),
 
@@ -344,21 +274,13 @@ impl ConstValue {
 
     pub fn shl(&self, other: &ConstValue) -> Option<ConstValue> {
         match (self, other) {
-            (ConstValue::Int(v1), ConstValue::Int(v2)) => {
-                v1.checked_shl(*v2 as _).map(ConstValue::Int)
-            }
+            (ConstValue::Int(v1), ConstValue::Int(v2)) => v1.checked_shl(*v2 as _).map(ConstValue::Int),
 
-            (ConstValue::Uint(v1), ConstValue::Uint(v2)) => {
-                v1.checked_shl(*v2 as _).map(ConstValue::Uint)
-            }
+            (ConstValue::Uint(v1), ConstValue::Uint(v2)) => v1.checked_shl(*v2 as _).map(ConstValue::Uint),
 
-            (ConstValue::Int(v1), ConstValue::Uint(v2)) => {
-                v1.checked_shl(*v2 as _).map(ConstValue::Int)
-            }
+            (ConstValue::Int(v1), ConstValue::Uint(v2)) => v1.checked_shl(*v2 as _).map(ConstValue::Int),
 
-            (ConstValue::Uint(v1), ConstValue::Int(v2)) => {
-                (*v1 as i64).checked_shl(*v2 as _).map(ConstValue::Int)
-            }
+            (ConstValue::Uint(v1), ConstValue::Int(v2)) => (*v1 as i64).checked_shl(*v2 as _).map(ConstValue::Int),
 
             _ => panic!("got {:?}", self),
         }
@@ -366,21 +288,13 @@ impl ConstValue {
 
     pub fn shr(&self, other: &ConstValue) -> Option<ConstValue> {
         match (self, other) {
-            (ConstValue::Int(v1), ConstValue::Int(v2)) => {
-                v1.checked_shr(*v2 as _).map(ConstValue::Int)
-            }
+            (ConstValue::Int(v1), ConstValue::Int(v2)) => v1.checked_shr(*v2 as _).map(ConstValue::Int),
 
-            (ConstValue::Uint(v1), ConstValue::Uint(v2)) => {
-                v1.checked_shr(*v2 as _).map(ConstValue::Uint)
-            }
+            (ConstValue::Uint(v1), ConstValue::Uint(v2)) => v1.checked_shr(*v2 as _).map(ConstValue::Uint),
 
-            (ConstValue::Int(v1), ConstValue::Uint(v2)) => {
-                v1.checked_shr(*v2 as _).map(ConstValue::Int)
-            }
+            (ConstValue::Int(v1), ConstValue::Uint(v2)) => v1.checked_shr(*v2 as _).map(ConstValue::Int),
 
-            (ConstValue::Uint(v1), ConstValue::Int(v2)) => {
-                (*v1 as i64).checked_shr(*v2 as _).map(ConstValue::Int)
-            }
+            (ConstValue::Uint(v1), ConstValue::Int(v2)) => (*v1 as i64).checked_shr(*v2 as _).map(ConstValue::Int),
 
             _ => panic!("got {:?}", self),
         }

--- a/src/hir/const_value.rs
+++ b/src/hir/const_value.rs
@@ -50,6 +50,7 @@ pub struct ConstFunction {
 pub struct ConstExternVariable {
     pub name: Ustr,
     pub lib: Option<ExternLibrary>,
+    pub dylib: Option<ExternLibrary>,
     pub ty: TypeId,
 }
 

--- a/src/hir/mod.rs
+++ b/src/hir/mod.rs
@@ -56,8 +56,7 @@ impl Cache {
     }
 
     pub fn entry_point_function(&self) -> Option<&Function> {
-        self.entry_point_function_id
-            .and_then(|id| self.functions.get(id))
+        self.entry_point_function_id.and_then(|id| self.functions.get(id))
     }
 }
 
@@ -87,7 +86,7 @@ pub enum FunctionKind {
     Orphan {
         params: Vec<FunctionParam>,
         inferred_return_type_span: Option<Span>, // This span will be filled when the function's return type is elided
-        body: Option<Sequence>, // The body will be filled after the function is fully checked
+        body: Option<Sequence>,                  // The body will be filled after the function is fully checked
     },
     Extern {
         lib: Option<ExternLibrary>,

--- a/src/hir/mod.rs
+++ b/src/hir/mod.rs
@@ -91,6 +91,7 @@ pub enum FunctionKind {
     Extern {
         lib: Option<ExternLibrary>,
         dylib: Option<ExternLibrary>,
+        link_name: Ustr,
     },
     Intrinsic(Intrinsic),
 }

--- a/src/hir/mod.rs
+++ b/src/hir/mod.rs
@@ -90,6 +90,7 @@ pub enum FunctionKind {
     },
     Extern {
         lib: Option<ExternLibrary>,
+        dylib: Option<ExternLibrary>,
     },
     Intrinsic(Intrinsic),
 }

--- a/src/hir/pretty.rs
+++ b/src/hir/pretty.rs
@@ -144,7 +144,7 @@ impl<'a, W: Write> Print<'a, W> for hir::Function {
     fn print(&self, p: &mut Printer<'a, W>, is_line_start: bool) {
         match &self.kind {
             hir::FunctionKind::Orphan { .. } => p.write_indented("fn ", is_line_start),
-            hir::FunctionKind::Extern { lib } => {
+            hir::FunctionKind::Extern { lib, .. } => {
                 if let Some(lib) = lib {
                     p.write_indented(&format!("extern fn \"{}\" ", lib.path()), is_line_start)
                 } else {

--- a/src/hir/pretty.rs
+++ b/src/hir/pretty.rs
@@ -90,10 +90,7 @@ impl<'a, W: Write> Print<'a, W> for hir::Cache {
             .for_each(|(module_id, items)| {
                 let module_info = p.workspace.module_infos.get(module_id).unwrap();
 
-                p.write_comment(
-                    &format!("{} ({})\n\n", module_info.name, module_info.file_path),
-                    true,
-                );
+                p.write_comment(&format!("{} ({})\n\n", module_info.name, module_info.file_path), true);
 
                 for item in items {
                     match item {
@@ -265,10 +262,7 @@ impl<'a, W: Write> Print<'a, W> for ConstValue {
 
 impl<'a, W: Write> Print<'a, W> for hir::Id {
     fn print(&self, p: &mut Printer<'a, W>, is_line_start: bool) {
-        p.write_indented(
-            &p.workspace.binding_infos.get(self.id).unwrap().name,
-            is_line_start,
-        );
+        p.write_indented(&p.workspace.binding_infos.get(self.id).unwrap().name, is_line_start);
     }
 }
 
@@ -371,12 +365,7 @@ impl<'a, W: Write> Print<'a, W> for hir::Control {
 
 impl<'a, W: Write> Print<'a, W> for hir::Builtin {
     fn print(&self, p: &mut Printer<'a, W>, is_line_start: bool) {
-        fn write_binary<'a, W: Write>(
-            op: &str,
-            binary: &hir::Binary,
-            p: &mut Printer<'a, W>,
-            is_line_start: bool,
-        ) {
+        fn write_binary<'a, W: Write>(op: &str, binary: &hir::Binary, p: &mut Printer<'a, W>, is_line_start: bool) {
             binary.lhs.print(p, is_line_start);
             p.write(" ");
             p.write(op);

--- a/src/ide/hint.rs
+++ b/src/ide/hint.rs
@@ -105,9 +105,10 @@ impl<'a> CollectHints<'a> for hir::Function {
                         continue;
                     }
 
-                    if binding_info.flags.contains(
-                        BindingInfoFlags::IS_USER_DEFINED | BindingInfoFlags::TYPE_WAS_INFERRED,
-                    ) {
+                    if binding_info
+                        .flags
+                        .contains(BindingInfoFlags::IS_USER_DEFINED | BindingInfoFlags::TYPE_WAS_INFERRED)
+                    {
                         sess.push_hint(binding_info.span, ty.to_string(), HintKind::Binding)
                     } else if binding_info
                         .flags
@@ -134,17 +135,9 @@ impl<'a> CollectHints<'a> for hir::Function {
                 }
 
                 if let Some(span) = inferred_return_type_span {
-                    match self
-                        .ty
-                        .normalize(sess.tcx)
-                        .into_function()
-                        .return_type
-                        .as_ref()
-                    {
+                    match self.ty.normalize(sess.tcx).into_function().return_type.as_ref() {
                         Type::Unit => (),
-                        return_type => {
-                            sess.push_hint(*span, return_type.to_string(), HintKind::ReturnType)
-                        }
+                        return_type => sess.push_hint(*span, return_type.to_string(), HintKind::ReturnType),
                     }
                 }
 
@@ -249,9 +242,7 @@ impl<'a> CollectHints<'a> for hir::Builtin {
             | hir::Builtin::BitAnd(x)
             | hir::Builtin::BitOr(x)
             | hir::Builtin::BitXor(x) => x.collect_hints(sess),
-            hir::Builtin::Not(x) | hir::Builtin::Neg(x) | hir::Builtin::Deref(x) => {
-                x.collect_hints(sess)
-            }
+            hir::Builtin::Not(x) | hir::Builtin::Neg(x) | hir::Builtin::Deref(x) => x.collect_hints(sess),
             hir::Builtin::Ref(x) => x.collect_hints(sess),
             hir::Builtin::Offset(x) => x.collect_hints(sess),
             hir::Builtin::Slice(x) => x.collect_hints(sess),

--- a/src/ide/mod.rs
+++ b/src/ide/mod.rs
@@ -70,16 +70,11 @@ pub fn diagnostics(workspace: &Workspace, tcx: Option<&TypeCtx>, typed_ast: Opti
 
 pub fn hover_info(workspace: &Workspace, tcx: Option<&TypeCtx>, offset: usize) {
     if let Some(tcx) = tcx {
-        let searched_binding_info =
-            workspace
-                .binding_infos
-                .iter()
-                .map(|(_, b)| b)
-                .find(|binding_info| {
-                    binding_info.module_id == workspace.root_module_id
-                        && binding_info.is_is_user_defined()
-                        && binding_info.span.contains(offset)
-                });
+        let searched_binding_info = workspace.binding_infos.iter().map(|(_, b)| b).find(|binding_info| {
+            binding_info.module_id == workspace.root_module_id
+                && binding_info.is_is_user_defined()
+                && binding_info.span.contains(offset)
+        });
 
         if let Some(binding_info) = searched_binding_info {
             write(&HoverInfo {
@@ -105,10 +100,7 @@ pub fn goto_definition(workspace: &Workspace, tcx: Option<&TypeCtx>, offset: usi
                             end: EndPosition::initial(),
                         };
 
-                        write(&IdeSpan::from_span_and_file(
-                            span,
-                            module_info.file_path.to_string(),
-                        ));
+                        write(&IdeSpan::from_span_and_file(span, module_info.file_path.to_string()));
 
                         return;
                     }

--- a/src/ide/types.rs
+++ b/src/ide/types.rs
@@ -23,12 +23,7 @@ impl IdeSpan {
         let module_id = workspace.find_module_id_by_file_id(span.file_id).unwrap();
         Self::from_span_and_file(
             span,
-            workspace
-                .module_infos
-                .get(module_id)
-                .unwrap()
-                .file_path
-                .to_string(),
+            workspace.module_infos.get(module_id).unwrap().file_path.to_string(),
         )
     }
 }

--- a/src/infer/cast.rs
+++ b/src/infer/cast.rs
@@ -17,9 +17,7 @@ pub fn can_cast_type(from: &Type, to: &Type) -> bool {
             | (Type::Int(_), Type::Infer(_, InferType::AnyFloat))
             | (Type::Int(_), Type::Float(_)) => true,
 
-            (Type::Uint(_), Type::Int(_))
-            | (Type::Uint(_), Type::Uint(_))
-            | (Type::Uint(_), Type::Float(_)) => true,
+            (Type::Uint(_), Type::Int(_)) | (Type::Uint(_), Type::Uint(_)) | (Type::Uint(_), Type::Float(_)) => true,
 
             (Type::Infer(_, InferType::AnyFloat), Type::Infer(_, InferType::AnyInt))
             | (Type::Infer(_, InferType::AnyFloat), Type::Int(_))
@@ -27,9 +25,7 @@ pub fn can_cast_type(from: &Type, to: &Type) -> bool {
             | (Type::Infer(_, InferType::AnyFloat), Type::Infer(_, InferType::AnyFloat))
             | (Type::Infer(_, InferType::AnyFloat), Type::Float(_)) => true,
 
-            (Type::Float(_), Type::Int(_))
-            | (Type::Float(_), Type::Uint(_))
-            | (Type::Float(_), Type::Float(_)) => true,
+            (Type::Float(_), Type::Int(_)) | (Type::Float(_), Type::Uint(_)) | (Type::Float(_), Type::Float(_)) => true,
 
             (Type::Pointer(..), Type::Int(..)) | (Type::Pointer(..), Type::Uint(..)) => true,
 

--- a/src/infer/coerce.rs
+++ b/src/infer/coerce.rs
@@ -22,12 +22,8 @@ impl Coerce for Type {
         use CoercionResult::*;
 
         match (self, to) {
-            (Type::Infer(_, InferType::AnyInt), Type::Infer(_, InferType::AnyFloat)) => {
-                CoerceToRight
-            }
-            (Type::Infer(_, InferType::AnyFloat), Type::Infer(_, InferType::AnyInt)) => {
-                CoerceToLeft
-            }
+            (Type::Infer(_, InferType::AnyInt), Type::Infer(_, InferType::AnyFloat)) => CoerceToRight,
+            (Type::Infer(_, InferType::AnyFloat), Type::Infer(_, InferType::AnyInt)) => CoerceToLeft,
 
             // * int -> same or bigger int
             (Type::Int(left), Type::Int(right)) => {

--- a/src/infer/display.rs
+++ b/src/infer/display.rs
@@ -37,8 +37,6 @@ impl OrReportErr for UnifyTypeResult {
         found: impl DisplayTy,
         found_span: Span,
     ) -> DiagnosticResult<()> {
-        self.map_err(|e| {
-            UnifyTypeErr::into_diagnostic(e, tcx, expected, expected_span, found, found_span)
-        })
+        self.map_err(|e| UnifyTypeErr::into_diagnostic(e, tcx, expected, expected_span, found, found_span))
     }
 }

--- a/src/infer/normalize.rs
+++ b/src/infer/normalize.rs
@@ -128,11 +128,7 @@ impl NormalizeCtx {
             Type::Pointer(inner, a) => Type::Pointer(Box::new(self.normalize_kind(tcx, inner)), *a),
             Type::Array(inner, a) => Type::Array(Box::new(self.normalize_kind(tcx, inner)), *a),
             Type::Slice(inner) => Type::Slice(Box::new(self.normalize_kind(tcx, inner))),
-            Type::Tuple(tys) => Type::Tuple(
-                tys.iter()
-                    .map(|kind| self.normalize_kind(tcx, kind))
-                    .collect(),
-            ),
+            Type::Tuple(tys) => Type::Tuple(tys.iter().map(|kind| self.normalize_kind(tcx, kind)).collect()),
             Type::Struct(st) => {
                 if st.binding_id != Default::default() && st.binding_id == self.parent_binding_id {
                     kind.clone()
@@ -174,12 +170,7 @@ impl NormalizeCtx {
                 } else {
                     Type::Infer(
                         *ty,
-                        InferType::PartialTuple(
-                            elements
-                                .iter()
-                                .map(|ty| self.normalize_kind(tcx, ty))
-                                .collect(),
-                        ),
+                        InferType::PartialTuple(elements.iter().map(|ty| self.normalize_kind(tcx, ty)).collect()),
                     )
                 }
             }
@@ -202,8 +193,7 @@ impl NormalizeCtx {
                     Type::Infer(
                         *ty,
                         InferType::PartialStruct(PartialStructType(IndexMap::from_iter(
-                            st.iter()
-                                .map(|(symbol, ty)| (*symbol, self.normalize_kind(tcx, ty))),
+                            st.iter().map(|(symbol, ty)| (*symbol, self.normalize_kind(tcx, ty))),
                         ))),
                     )
                 }

--- a/src/infer/unify.rs
+++ b/src/infer/unify.rs
@@ -1,6 +1,4 @@
-use super::{
-    display::DisplayTy, inference_value::InferenceValue, normalize::Normalize, type_ctx::TypeCtx,
-};
+use super::{display::DisplayTy, inference_value::InferenceValue, normalize::Normalize, type_ctx::TypeCtx};
 use crate::{
     common::builtin::{BUILTIN_FIELD_DATA, BUILTIN_FIELD_LEN},
     error::diagnostic::{Diagnostic, Label},
@@ -242,8 +240,7 @@ fn unify_var_ty(var: TypeId, other: &Type, tcx: &mut TypeCtx) -> UnifyTypeResult
         InferenceValue::PartialTuple(partial_tuple) => {
             let other_kind = other.normalize(tcx);
             match other_kind {
-                Type::Tuple(ref other_tuple)
-                | Type::Infer(_, InferType::PartialTuple(ref other_tuple)) => {
+                Type::Tuple(ref other_tuple) | Type::Infer(_, InferType::PartialTuple(ref other_tuple)) => {
                     let mut any_err = false;
 
                     if other_tuple.len() < partial_tuple.len() {
@@ -293,18 +290,12 @@ pub fn occurs(var: TypeId, kind: &Type, tcx: &TypeCtx) -> bool {
             use InferenceValue::*;
             match tcx.value_of(other) {
                 Bound(ty) => occurs(var, ty, tcx) || var == other,
-                PartialStruct(partial) => {
-                    partial.values().any(|ty| occurs(var, ty, tcx)) || var == other
-                }
-                PartialTuple(partial) => {
-                    partial.iter().any(|ty| occurs(var, ty, tcx)) || var == other
-                }
+                PartialStruct(partial) => partial.values().any(|ty| occurs(var, ty, tcx)) || var == other,
+                PartialTuple(partial) => partial.iter().any(|ty| occurs(var, ty, tcx)) || var == other,
                 AnyInt | AnyFloat | Unbound => var == other,
             }
         }
-        Type::Function(f) => {
-            f.params.iter().any(|p| occurs(var, &p.ty, tcx)) || occurs(var, &f.return_type, tcx)
-        }
+        Type::Function(f) => f.params.iter().any(|p| occurs(var, &p.ty, tcx)) || occurs(var, &f.return_type, tcx),
         Type::Array(ty, _) => occurs(var, ty, tcx),
         Type::Tuple(tys) => tys.iter().any(|ty| occurs(var, ty, tcx)),
         Type::Struct(st) => st.fields.iter().any(|f| occurs(var, &f.ty, tcx)),
@@ -340,14 +331,9 @@ impl UnifyTypeErr {
 
         match self {
             UnifyTypeErr::Mismatch => Diagnostic::error()
-                .with_message(format!(
-                    "mismatched types - expected {}, found {}",
-                    expected, found
-                ))
+                .with_message(format!("mismatched types - expected {}, found {}", expected, found))
                 .with_label(Label::primary(found_span, format!("expected {}", expected)))
-                .maybe_with_label(
-                    expected_span.map(|span| Label::secondary(span, "expected due to this")),
-                ),
+                .maybe_with_label(expected_span.map(|span| Label::secondary(span, "expected due to this"))),
             UnifyTypeErr::Occurs => Diagnostic::error()
                 .with_message(format!("recursive type `{}` has infinite size", expected,))
                 .with_label(Label::primary(found_span, "type is recursive")),

--- a/src/interp/interp.rs
+++ b/src/interp/interp.rs
@@ -172,9 +172,11 @@ impl<'i> InterpSess<'i> {
                 },
             );
 
-            self.interp
-                .constants
-                .push(Value::Function(FunctionAddress { id, name }));
+            self.interp.constants.push(Value::Function(FunctionAddress {
+                id,
+                is_extern: false,
+                name,
+            }));
 
             code.write_inst(Inst::LoadConst(const_slot as u32));
         }

--- a/src/interp/lower.rs
+++ b/src/interp/lower.rs
@@ -92,8 +92,8 @@ impl Lower for hir::Function {
                     },
                 );
             }
-            hir::FunctionKind::Extern { lib } => {
-                let lib_path = lib.as_ref().map_or_else(
+            hir::FunctionKind::Extern { dylib, .. } => {
+                let lib_path = dylib.as_ref().map_or_else(
                     || {
                         sess.diagnostics.push(
                             Diagnostic::error()
@@ -893,14 +893,13 @@ fn const_value_to_value(const_value: &ConstValue, ty: TypeId, sess: &mut InterpS
                 }),
                 _ => {
                     function.lower(sess, &mut Bytecode::new(), LowerContext { take_ptr: false });
-
                     Value::Function(FunctionAddress { id: f.id, name: f.name })
                 }
             }
         }
         ConstValue::ExternVariable(variable) => Value::ExternVariable(ExternVariable {
             name: variable.name,
-            lib: variable.lib.clone().unwrap(),
+            lib: variable.dylib.clone().unwrap(),
             ty: variable.ty.normalize(sess.tcx),
         }),
     }

--- a/src/interp/lower.rs
+++ b/src/interp/lower.rs
@@ -15,9 +15,7 @@ use crate::{
     },
     infer::normalize::Normalize,
     interp::vm::value::FunctionAddress,
-    types::{
-        offset_of::OffsetOf, size_of::SizeOf, FloatType, InferType, IntType, Type, TypeId, UintType,
-    },
+    types::{offset_of::OffsetOf, size_of::SizeOf, FloatType, InferType, IntType, Type, TypeId, UintType},
     workspace::{BindingId, BindingInfoKind},
 };
 use byteorder::{NativeEndian, WriteBytesExt};
@@ -76,11 +74,9 @@ impl Lower for hir::Function {
                     sess.env_mut().insert(params[index].id, offset);
                 }
 
-                body.as_ref().unwrap().lower(
-                    sess,
-                    &mut function_code,
-                    LowerContext { take_ptr: false },
-                );
+                body.as_ref()
+                    .unwrap()
+                    .lower(sess, &mut function_code, LowerContext { take_ptr: false });
 
                 function_code.write_inst(Inst::Return);
 
@@ -102,13 +98,11 @@ impl Lower for hir::Function {
                         sess.diagnostics.push(
                             Diagnostic::error()
                                 .with_message(format!(
-                            "must specify `dylib` to use extern function `{}` at compile-time",
-                            self.name
-                        ))
-                                .with_label(Label::primary(
-                                    self.span,
-                                    "cannot run during compile-time",
-                                )),
+                                    "must specify a library to use extern variable `{}` at compile-time",
+                                    self.name
+                                ))
+                                .with_label(Label::primary(self.span, "cannot use during compile-time"))
+                                .with_note("add #[lib = \"your_lib\"] above the declaration"),
                         );
 
                         ustr("")
@@ -136,16 +130,15 @@ impl Lower for hir::Function {
 
 impl Lower for hir::Binding {
     fn lower(&self, sess: &mut InterpSess, code: &mut Bytecode, _ctx: LowerContext) {
-        if let Some(ConstValue::ExternVariable(ConstExternVariable { lib: None, .. })) =
-            self.value.as_const_value()
-        {
+        if let Some(ConstValue::ExternVariable(ConstExternVariable { lib: None, .. })) = self.value.as_const_value() {
             sess.diagnostics.push(
                 Diagnostic::error()
                     .with_message(format!(
-                        "must specify `dylib` to use extern variable `{}` at compile-time",
+                        "must specify a library to use extern variable `{}` at compile-time",
                         self.name
                     ))
-                    .with_label(Label::primary(self.span, "cannot use during compile-time")),
+                    .with_label(Label::primary(self.span, "cannot use during compile-time"))
+                    .with_note("add #[lib = \"your_lib\"] above the declaration"),
             );
 
             return;
@@ -158,8 +151,7 @@ impl Lower for hir::Binding {
                 lower_static_binding(self, sess);
             }
             _ => {
-                self.value
-                    .lower(sess, code, LowerContext { take_ptr: false });
+                self.value.lower(sess, code, LowerContext { take_ptr: false });
 
                 sess.add_local(code, self.id);
                 let last_local = code.locals as i32 - 1;
@@ -228,8 +220,7 @@ impl Lower for hir::Call {
             arg.lower(sess, code, LowerContext { take_ptr: false });
         }
 
-        self.callee
-            .lower(sess, code, LowerContext { take_ptr: false });
+        self.callee.lower(sess, code, LowerContext { take_ptr: false });
 
         code.write_inst(Inst::Call(self.args.len() as u32));
     }
@@ -237,8 +228,7 @@ impl Lower for hir::Call {
 
 impl Lower for hir::Cast {
     fn lower(&self, sess: &mut InterpSess, code: &mut Bytecode, _ctx: LowerContext) {
-        self.value
-            .lower(sess, code, LowerContext { take_ptr: false });
+        self.value.lower(sess, code, LowerContext { take_ptr: false });
 
         let target_type = self.ty.normalize(sess.tcx);
 
@@ -253,8 +243,7 @@ impl Lower for hir::Cast {
                     sess.push_const(code, Value::Type(value_type.clone()));
                     code.write_inst(Inst::BufferAlloc(value_type_size));
 
-                    self.value
-                        .lower(sess, code, LowerContext { take_ptr: true });
+                    self.value.lower(sess, code, LowerContext { take_ptr: true });
 
                     // calculate the new slice's offset
                     sess.push_const(code, Value::Uint(0));
@@ -299,15 +288,7 @@ impl Lower for hir::Sequence {
         for (index, expr) in self.statements.iter().enumerate() {
             let is_last = index == self.statements.len() - 1;
 
-            expr.lower(
-                sess,
-                code,
-                if is_last {
-                    ctx
-                } else {
-                    LowerContext { take_ptr: false }
-                },
-            );
+            expr.lower(sess, code, if is_last { ctx } else { LowerContext { take_ptr: false } });
 
             if !is_last {
                 code.write_inst(Inst::Pop);
@@ -328,19 +309,11 @@ impl Lower for hir::Control {
             hir::Control::Return(x) => x.lower(sess, code, ctx),
             hir::Control::Break(_) => {
                 let pos = code.write_inst(Inst::Jmp(INVALID_JMP_OFFSET));
-                sess.loop_env_stack
-                    .last_mut()
-                    .unwrap()
-                    .break_offsets
-                    .push(pos);
+                sess.loop_env_stack.last_mut().unwrap().break_offsets.push(pos);
             }
             hir::Control::Continue(_) => {
                 let pos = code.write_inst(Inst::Jmp(INVALID_JMP_OFFSET));
-                sess.loop_env_stack
-                    .last_mut()
-                    .unwrap()
-                    .break_offsets
-                    .push(pos);
+                sess.loop_env_stack.last_mut().unwrap().break_offsets.push(pos);
             }
         }
     }
@@ -351,14 +324,8 @@ impl Lower for hir::If {
         lower_conditional(
             sess,
             code,
-            |sess, code| {
-                self.condition
-                    .lower(sess, code, LowerContext { take_ptr: false })
-            },
-            |sess, code| {
-                self.then
-                    .lower(sess, code, LowerContext { take_ptr: false })
-            },
+            |sess, code| self.condition.lower(sess, code, LowerContext { take_ptr: false }),
+            |sess, code| self.then.lower(sess, code, LowerContext { take_ptr: false }),
             |sess, code| {
                 if let Some(otherwise) = &self.otherwise {
                     otherwise.lower(sess, code, LowerContext { take_ptr: false });
@@ -396,15 +363,13 @@ impl Lower for hir::While {
     fn lower(&self, sess: &mut InterpSess, code: &mut Bytecode, _ctx: LowerContext) {
         let loop_start = code.len();
 
-        self.condition
-            .lower(sess, code, LowerContext { take_ptr: false });
+        self.condition.lower(sess, code, LowerContext { take_ptr: false });
 
         let exit_jmp = code.write_inst(Inst::Jmpf(INVALID_JMP_OFFSET));
 
         sess.loop_env_stack.push(LoopEnv::new());
 
-        self.body
-            .lower(sess, code, LowerContext { take_ptr: false });
+        self.body.lower(sess, code, LowerContext { take_ptr: false });
 
         let loop_env = sess.loop_env_stack.pop().unwrap();
 
@@ -437,8 +402,7 @@ impl Lower for hir::While {
 
 impl Lower for hir::Return {
     fn lower(&self, sess: &mut InterpSess, code: &mut Bytecode, _ctx: LowerContext) {
-        self.value
-            .lower(sess, code, LowerContext { take_ptr: false });
+        self.value.lower(sess, code, LowerContext { take_ptr: false });
         code.write_inst(Inst::Return);
     }
 }
@@ -447,72 +411,44 @@ impl Lower for hir::Builtin {
     fn lower(&self, sess: &mut InterpSess, code: &mut Bytecode, ctx: LowerContext) {
         match self {
             hir::Builtin::Add(binary) => {
-                binary
-                    .lhs
-                    .lower(sess, code, LowerContext { take_ptr: false });
-                binary
-                    .rhs
-                    .lower(sess, code, LowerContext { take_ptr: false });
+                binary.lhs.lower(sess, code, LowerContext { take_ptr: false });
+                binary.rhs.lower(sess, code, LowerContext { take_ptr: false });
 
                 code.write_inst(Inst::Add);
             }
             hir::Builtin::Sub(binary) => {
-                binary
-                    .lhs
-                    .lower(sess, code, LowerContext { take_ptr: false });
-                binary
-                    .rhs
-                    .lower(sess, code, LowerContext { take_ptr: false });
+                binary.lhs.lower(sess, code, LowerContext { take_ptr: false });
+                binary.rhs.lower(sess, code, LowerContext { take_ptr: false });
 
                 code.write_inst(Inst::Sub);
             }
             hir::Builtin::Mul(binary) => {
-                binary
-                    .lhs
-                    .lower(sess, code, LowerContext { take_ptr: false });
-                binary
-                    .rhs
-                    .lower(sess, code, LowerContext { take_ptr: false });
+                binary.lhs.lower(sess, code, LowerContext { take_ptr: false });
+                binary.rhs.lower(sess, code, LowerContext { take_ptr: false });
 
                 code.write_inst(Inst::Mul);
             }
             hir::Builtin::Div(binary) => {
-                binary
-                    .lhs
-                    .lower(sess, code, LowerContext { take_ptr: false });
-                binary
-                    .rhs
-                    .lower(sess, code, LowerContext { take_ptr: false });
+                binary.lhs.lower(sess, code, LowerContext { take_ptr: false });
+                binary.rhs.lower(sess, code, LowerContext { take_ptr: false });
 
                 code.write_inst(Inst::Div);
             }
             hir::Builtin::Rem(binary) => {
-                binary
-                    .lhs
-                    .lower(sess, code, LowerContext { take_ptr: false });
-                binary
-                    .rhs
-                    .lower(sess, code, LowerContext { take_ptr: false });
+                binary.lhs.lower(sess, code, LowerContext { take_ptr: false });
+                binary.rhs.lower(sess, code, LowerContext { take_ptr: false });
 
                 code.write_inst(Inst::Rem);
             }
             hir::Builtin::Shl(binary) => {
-                binary
-                    .lhs
-                    .lower(sess, code, LowerContext { take_ptr: false });
-                binary
-                    .rhs
-                    .lower(sess, code, LowerContext { take_ptr: false });
+                binary.lhs.lower(sess, code, LowerContext { take_ptr: false });
+                binary.rhs.lower(sess, code, LowerContext { take_ptr: false });
 
                 code.write_inst(Inst::Shl);
             }
             hir::Builtin::Shr(binary) => {
-                binary
-                    .lhs
-                    .lower(sess, code, LowerContext { take_ptr: false });
-                binary
-                    .rhs
-                    .lower(sess, code, LowerContext { take_ptr: false });
+                binary.lhs.lower(sess, code, LowerContext { take_ptr: false });
+                binary.rhs.lower(sess, code, LowerContext { take_ptr: false });
 
                 code.write_inst(Inst::Shr);
             }
@@ -521,14 +457,10 @@ impl Lower for hir::Builtin {
                     sess,
                     code,
                     |sess, code| {
-                        binary
-                            .lhs
-                            .lower(sess, code, LowerContext { take_ptr: false });
+                        binary.lhs.lower(sess, code, LowerContext { take_ptr: false });
                     },
                     |sess, code| {
-                        binary
-                            .rhs
-                            .lower(sess, code, LowerContext { take_ptr: false });
+                        binary.rhs.lower(sess, code, LowerContext { take_ptr: false });
                     },
                     |sess, code| {
                         sess.push_const(code, Value::Bool(false));
@@ -540,140 +472,90 @@ impl Lower for hir::Builtin {
                     sess,
                     code,
                     |sess, code| {
-                        binary
-                            .lhs
-                            .lower(sess, code, LowerContext { take_ptr: false });
+                        binary.lhs.lower(sess, code, LowerContext { take_ptr: false });
                     },
                     |sess, code| {
                         sess.push_const(code, Value::Bool(true));
                     },
                     |sess, code| {
-                        binary
-                            .rhs
-                            .lower(sess, code, LowerContext { take_ptr: false });
+                        binary.rhs.lower(sess, code, LowerContext { take_ptr: false });
                     },
                 );
             }
             hir::Builtin::Lt(binary) => {
-                binary
-                    .lhs
-                    .lower(sess, code, LowerContext { take_ptr: false });
-                binary
-                    .rhs
-                    .lower(sess, code, LowerContext { take_ptr: false });
+                binary.lhs.lower(sess, code, LowerContext { take_ptr: false });
+                binary.rhs.lower(sess, code, LowerContext { take_ptr: false });
 
                 code.write_inst(Inst::Lt);
             }
             hir::Builtin::Le(binary) => {
-                binary
-                    .lhs
-                    .lower(sess, code, LowerContext { take_ptr: false });
-                binary
-                    .rhs
-                    .lower(sess, code, LowerContext { take_ptr: false });
+                binary.lhs.lower(sess, code, LowerContext { take_ptr: false });
+                binary.rhs.lower(sess, code, LowerContext { take_ptr: false });
 
                 code.write_inst(Inst::Le);
             }
             hir::Builtin::Gt(binary) => {
-                binary
-                    .lhs
-                    .lower(sess, code, LowerContext { take_ptr: false });
-                binary
-                    .rhs
-                    .lower(sess, code, LowerContext { take_ptr: false });
+                binary.lhs.lower(sess, code, LowerContext { take_ptr: false });
+                binary.rhs.lower(sess, code, LowerContext { take_ptr: false });
 
                 code.write_inst(Inst::Gt);
             }
             hir::Builtin::Ge(binary) => {
-                binary
-                    .lhs
-                    .lower(sess, code, LowerContext { take_ptr: false });
-                binary
-                    .rhs
-                    .lower(sess, code, LowerContext { take_ptr: false });
+                binary.lhs.lower(sess, code, LowerContext { take_ptr: false });
+                binary.rhs.lower(sess, code, LowerContext { take_ptr: false });
 
                 code.write_inst(Inst::Ge);
             }
             hir::Builtin::Eq(binary) => {
-                binary
-                    .lhs
-                    .lower(sess, code, LowerContext { take_ptr: false });
-                binary
-                    .rhs
-                    .lower(sess, code, LowerContext { take_ptr: false });
+                binary.lhs.lower(sess, code, LowerContext { take_ptr: false });
+                binary.rhs.lower(sess, code, LowerContext { take_ptr: false });
 
                 code.write_inst(Inst::Eq);
             }
             hir::Builtin::Ne(binary) => {
-                binary
-                    .lhs
-                    .lower(sess, code, LowerContext { take_ptr: false });
-                binary
-                    .rhs
-                    .lower(sess, code, LowerContext { take_ptr: false });
+                binary.lhs.lower(sess, code, LowerContext { take_ptr: false });
+                binary.rhs.lower(sess, code, LowerContext { take_ptr: false });
 
                 code.write_inst(Inst::Ne);
             }
             hir::Builtin::BitAnd(binary) => {
-                binary
-                    .lhs
-                    .lower(sess, code, LowerContext { take_ptr: false });
-                binary
-                    .rhs
-                    .lower(sess, code, LowerContext { take_ptr: false });
+                binary.lhs.lower(sess, code, LowerContext { take_ptr: false });
+                binary.rhs.lower(sess, code, LowerContext { take_ptr: false });
 
                 code.write_inst(Inst::And);
             }
             hir::Builtin::BitOr(binary) => {
-                binary
-                    .lhs
-                    .lower(sess, code, LowerContext { take_ptr: false });
-                binary
-                    .rhs
-                    .lower(sess, code, LowerContext { take_ptr: false });
+                binary.lhs.lower(sess, code, LowerContext { take_ptr: false });
+                binary.rhs.lower(sess, code, LowerContext { take_ptr: false });
 
                 code.write_inst(Inst::Or);
             }
             hir::Builtin::BitXor(binary) => {
-                binary
-                    .lhs
-                    .lower(sess, code, LowerContext { take_ptr: false });
-                binary
-                    .rhs
-                    .lower(sess, code, LowerContext { take_ptr: false });
+                binary.lhs.lower(sess, code, LowerContext { take_ptr: false });
+                binary.rhs.lower(sess, code, LowerContext { take_ptr: false });
 
                 code.write_inst(Inst::Xor);
             }
             hir::Builtin::Not(unary) => {
-                unary
-                    .value
-                    .lower(sess, code, LowerContext { take_ptr: false });
+                unary.value.lower(sess, code, LowerContext { take_ptr: false });
 
                 code.write_inst(Inst::Not);
             }
             hir::Builtin::Neg(unary) => {
-                unary
-                    .value
-                    .lower(sess, code, LowerContext { take_ptr: false });
+                unary.value.lower(sess, code, LowerContext { take_ptr: false });
 
                 code.write_inst(Inst::Neg);
             }
             hir::Builtin::Ref(unary) => {
-                unary
-                    .value
-                    .lower(sess, code, LowerContext { take_ptr: true });
+                unary.value.lower(sess, code, LowerContext { take_ptr: true });
             }
             hir::Builtin::Deref(unary) => {
-                unary
-                    .value
-                    .lower(sess, code, LowerContext { take_ptr: false });
+                unary.value.lower(sess, code, LowerContext { take_ptr: false });
 
                 code.write_inst(Inst::Deref);
             }
             hir::Builtin::Offset(offset) => {
-                offset
-                    .value
-                    .lower(sess, code, LowerContext { take_ptr: false });
+                offset.value.lower(sess, code, LowerContext { take_ptr: false });
 
                 let value_type = offset.value.ty().normalize(sess.tcx);
 
@@ -689,19 +571,13 @@ impl Lower for hir::Builtin {
                     _ => unreachable!("{}", value_type),
                 };
 
-                offset
-                    .index
-                    .lower(sess, code, LowerContext { take_ptr: false });
+                offset.index.lower(sess, code, LowerContext { take_ptr: false });
 
                 sess.push_const(code, Value::Uint(elem_size));
 
                 code.write_inst(Inst::Mul);
 
-                code.write_inst(if ctx.take_ptr {
-                    Inst::IndexPtr
-                } else {
-                    Inst::Index
-                });
+                code.write_inst(if ctx.take_ptr { Inst::IndexPtr } else { Inst::Index });
             }
             hir::Builtin::Slice(slice) => {
                 let value_type = slice.value.ty().normalize(sess.tcx);
@@ -721,14 +597,10 @@ impl Lower for hir::Builtin {
                         sess.push_const(code, Value::Type(value_type.clone()));
                         code.write_inst(Inst::BufferAlloc(value_type_size));
 
-                        slice
-                            .value
-                            .lower(sess, code, LowerContext { take_ptr: true });
+                        slice.value.lower(sess, code, LowerContext { take_ptr: true });
 
                         // calculate the new slice's offset
-                        slice
-                            .low
-                            .lower(sess, code, LowerContext { take_ptr: false });
+                        slice.low.lower(sess, code, LowerContext { take_ptr: false });
                         sess.push_const(code, Value::Uint(elem_size));
                         code.write_inst(Inst::Mul);
                         code.write_inst(Inst::Offset);
@@ -736,21 +608,15 @@ impl Lower for hir::Builtin {
                         code.write_inst(Inst::BufferPut(0));
 
                         // calculate the slice length, by doing `high - low`
-                        slice
-                            .high
-                            .lower(sess, code, LowerContext { take_ptr: false });
-                        slice
-                            .low
-                            .lower(sess, code, LowerContext { take_ptr: false });
+                        slice.high.lower(sess, code, LowerContext { take_ptr: false });
+                        slice.low.lower(sess, code, LowerContext { take_ptr: false });
                         code.write_inst(Inst::Sub);
 
                         code.write_inst(Inst::BufferPut(WORD_SIZE as u32));
                     }
                     Type::Pointer(inner, _) => match inner.as_ref() {
                         Type::Slice(_) => {
-                            slice
-                                .value
-                                .lower(sess, code, LowerContext { take_ptr: false });
+                            slice.value.lower(sess, code, LowerContext { take_ptr: false });
 
                             code.write_inst(Inst::Copy(0));
                             code.write_inst(Inst::ConstIndex(1));
@@ -763,9 +629,7 @@ impl Lower for hir::Builtin {
                             code.write_inst(Inst::Swap(1));
 
                             // calculate the new slice's offset
-                            slice
-                                .low
-                                .lower(sess, code, LowerContext { take_ptr: false });
+                            slice.low.lower(sess, code, LowerContext { take_ptr: false });
                             sess.push_const(code, Value::Uint(elem_size));
                             code.write_inst(Inst::Mul);
                             code.write_inst(Inst::Offset);
@@ -773,12 +637,8 @@ impl Lower for hir::Builtin {
                             code.write_inst(Inst::BufferPut(0));
 
                             // calculate the slice length, by doing `high - low`
-                            slice
-                                .high
-                                .lower(sess, code, LowerContext { take_ptr: false });
-                            slice
-                                .low
-                                .lower(sess, code, LowerContext { take_ptr: false });
+                            slice.high.lower(sess, code, LowerContext { take_ptr: false });
+                            slice.low.lower(sess, code, LowerContext { take_ptr: false });
                             code.write_inst(Inst::Sub);
 
                             code.write_inst(Inst::BufferPut(WORD_SIZE as u32));
@@ -787,25 +647,17 @@ impl Lower for hir::Builtin {
                             sess.push_const(code, Value::Type(value_type.clone()));
                             code.write_inst(Inst::BufferAlloc(value_type_size));
 
-                            slice
-                                .value
-                                .lower(sess, code, LowerContext { take_ptr: false });
+                            slice.value.lower(sess, code, LowerContext { take_ptr: false });
 
-                            slice
-                                .low
-                                .lower(sess, code, LowerContext { take_ptr: false });
+                            slice.low.lower(sess, code, LowerContext { take_ptr: false });
                             sess.push_const(code, Value::Uint(elem_size));
                             code.write_inst(Inst::Mul);
                             code.write_inst(Inst::Offset);
 
                             code.write_inst(Inst::BufferPut(0));
 
-                            slice
-                                .high
-                                .lower(sess, code, LowerContext { take_ptr: false });
-                            slice
-                                .low
-                                .lower(sess, code, LowerContext { take_ptr: false });
+                            slice.high.lower(sess, code, LowerContext { take_ptr: false });
+                            slice.low.lower(sess, code, LowerContext { take_ptr: false });
                             code.write_inst(Inst::Sub);
 
                             code.write_inst(Inst::BufferPut(WORD_SIZE as u32));
@@ -847,13 +699,9 @@ impl Lower for hir::StructLiteral {
         });
 
         for (index, field) in ordered_fields.iter().enumerate() {
-            field
-                .value
-                .lower(sess, code, LowerContext { take_ptr: false });
+            field.value.lower(sess, code, LowerContext { take_ptr: false });
 
-            code.write_inst(Inst::BufferPut(
-                struct_type.offset_of(index, WORD_SIZE) as u32
-            ));
+            code.write_inst(Inst::BufferPut(struct_type.offset_of(index, WORD_SIZE) as u32));
         }
     }
 }
@@ -868,9 +716,7 @@ impl Lower for hir::TupleLiteral {
 
         for (index, element) in self.elements.iter().enumerate() {
             element.lower(sess, code, LowerContext { take_ptr: false });
-            code.write_inst(Inst::BufferPut(
-                tuple_type.offset_of(index, WORD_SIZE) as u32
-            ));
+            code.write_inst(Inst::BufferPut(tuple_type.offset_of(index, WORD_SIZE) as u32));
         }
     }
 }
@@ -881,9 +727,7 @@ impl Lower for hir::ArrayLiteral {
         let inner_ty_size = ty.element_type().unwrap().size_of(WORD_SIZE);
 
         sess.push_const(code, Value::Type(ty));
-        code.write_inst(Inst::BufferAlloc(
-            (self.elements.len() * inner_ty_size) as u32,
-        ));
+        code.write_inst(Inst::BufferAlloc((self.elements.len() * inner_ty_size) as u32));
 
         for (index, element) in self.elements.iter().enumerate() {
             element.lower(sess, code, LowerContext { take_ptr: false });
@@ -897,17 +741,12 @@ impl Lower for hir::ArrayFillLiteral {
         let ty = self.ty.normalize(sess.tcx);
         let inner_ty_size = ty.element_type().unwrap().size_of(WORD_SIZE);
 
-        let size = if let Type::Array(_, size) = ty {
-            size
-        } else {
-            panic!()
-        };
+        let size = if let Type::Array(_, size) = ty { size } else { panic!() };
 
         sess.push_const(code, Value::Type(ty));
         code.write_inst(Inst::BufferAlloc((size * inner_ty_size) as u32));
 
-        self.value
-            .lower(sess, code, LowerContext { take_ptr: false });
+        self.value.lower(sess, code, LowerContext { take_ptr: false });
 
         code.write_inst(Inst::BufferFill(size as u32));
     }
@@ -1055,10 +894,7 @@ fn const_value_to_value(const_value: &ConstValue, ty: TypeId, sess: &mut InterpS
                 _ => {
                     function.lower(sess, &mut Bytecode::new(), LowerContext { take_ptr: false });
 
-                    Value::Function(FunctionAddress {
-                        id: f.id,
-                        name: f.name,
-                    })
+                    Value::Function(FunctionAddress { id: f.id, name: f.name })
                 }
             }
         }
@@ -1094,9 +930,7 @@ fn lower_static_binding(binding: &hir::Binding, sess: &mut InterpSess) -> usize 
 
     sess.env_stack.push((binding.module_id, Env::default()));
 
-    binding
-        .value
-        .lower(sess, &mut code, LowerContext { take_ptr: false });
+    binding.value.lower(sess, &mut code, LowerContext { take_ptr: false });
 
     sess.env_stack.pop();
 

--- a/src/interp/lower.rs
+++ b/src/interp/lower.rs
@@ -98,7 +98,7 @@ impl Lower for hir::Function {
                         sess.diagnostics.push(
                             Diagnostic::error()
                                 .with_message(format!(
-                                    "must specify a library to use extern variable `{}` at compile-time",
+                                    "must specify a library to use extern function `{}` at compile-time",
                                     self.name
                                 ))
                                 .with_label(Label::primary(self.span, "cannot use during compile-time"))

--- a/src/interp/vm/byte_seq.rs
+++ b/src/interp/vm/byte_seq.rs
@@ -88,16 +88,12 @@ impl PutValue for [u8] {
             Value::I16(v) => self.as_mut().write_i16::<NativeEndian>(*v),
             Value::I32(v) => self.as_mut().write_i32::<NativeEndian>(*v),
             Value::I64(v) => self.as_mut().write_i64::<NativeEndian>(*v),
-            Value::Int(v) => self
-                .as_mut()
-                .write_int::<NativeEndian>(*v as i64, WORD_SIZE),
+            Value::Int(v) => self.as_mut().write_int::<NativeEndian>(*v as i64, WORD_SIZE),
             Value::U8(v) => self.as_mut().write_u8(*v),
             Value::U16(v) => self.as_mut().write_u16::<NativeEndian>(*v),
             Value::U32(v) => self.as_mut().write_u32::<NativeEndian>(*v),
             Value::U64(v) => self.as_mut().write_u64::<NativeEndian>(*v),
-            Value::Uint(v) => self
-                .as_mut()
-                .write_uint::<NativeEndian>(*v as u64, WORD_SIZE),
+            Value::Uint(v) => self.as_mut().write_uint::<NativeEndian>(*v as u64, WORD_SIZE),
             Value::F32(v) => self.as_mut().write_f32::<NativeEndian>(*v),
             Value::F64(v) => self.as_mut().write_f64::<NativeEndian>(*v),
             Value::Bool(v) => self.as_mut().write_u8(*v as u8),
@@ -109,10 +105,7 @@ impl PutValue for [u8] {
                 .as_mut()
                 .write_uint::<NativeEndian>(v.as_inner_raw() as u64, WORD_SIZE),
             Value::Function(_) => todo!(),
-            _ => panic!(
-                "can't convert `{}` to raw self.as_mut().inner",
-                value.to_string()
-            ),
+            _ => panic!("can't convert `{}` to raw self.as_mut().inner", value.to_string()),
         }
         .unwrap()
     }
@@ -138,23 +131,17 @@ impl GetValue for [u8] {
                 IntType::I16 => Value::I16(self.as_ref().read_i16::<NativeEndian>().unwrap()),
                 IntType::I32 => Value::I32(self.as_ref().read_i32::<NativeEndian>().unwrap()),
                 IntType::I64 => Value::I64(self.as_ref().read_i64::<NativeEndian>().unwrap()),
-                IntType::Int => {
-                    Value::Int(self.as_ref().read_int::<NativeEndian>(WORD_SIZE).unwrap() as isize)
-                }
+                IntType::Int => Value::Int(self.as_ref().read_int::<NativeEndian>(WORD_SIZE).unwrap() as isize),
             },
             Type::Uint(ty) => match ty {
                 UintType::U8 => Value::U8(self.as_ref().read_u8().unwrap()),
                 UintType::U16 => Value::U16(self.as_ref().read_u16::<NativeEndian>().unwrap()),
                 UintType::U32 => Value::U32(self.as_ref().read_u32::<NativeEndian>().unwrap()),
                 UintType::U64 => Value::U64(self.as_ref().read_u64::<NativeEndian>().unwrap()),
-                UintType::Uint => {
-                    Value::Uint(self.as_ref().read_uint::<NativeEndian>(WORD_SIZE).unwrap() as usize)
-                }
+                UintType::Uint => Value::Uint(self.as_ref().read_uint::<NativeEndian>(WORD_SIZE).unwrap() as usize),
             },
             Type::Float(ty) => match ty {
-                FloatType::F16 | FloatType::F32 => {
-                    Value::F32(self.as_ref().read_f32::<NativeEndian>().unwrap())
-                }
+                FloatType::F16 | FloatType::F32 => Value::F32(self.as_ref().read_f32::<NativeEndian>().unwrap()),
                 FloatType::F64 => Value::F64(self.as_ref().read_f64::<NativeEndian>().unwrap()),
                 FloatType::Float => {
                     if IS_64BIT {
@@ -189,10 +176,7 @@ impl GetValue for [u8] {
                     Value::F32(self.as_ref().read_f32::<NativeEndian>().unwrap())
                 }
             }
-            _ => panic!(
-                "can't get value of type `{}` from raw self.as_ref().inner",
-                ty
-            ),
+            _ => panic!("can't get value of type `{}` from raw self.as_ref().inner", ty),
         }
     }
 }

--- a/src/interp/vm/bytecode.rs
+++ b/src/interp/vm/bytecode.rs
@@ -26,10 +26,7 @@ impl IndexMut<usize> for Bytecode {
 
 impl Bytecode {
     pub fn new() -> Self {
-        Self {
-            buf: vec![],
-            locals: 0,
-        }
+        Self { buf: vec![], locals: 0 }
     }
 
     #[inline(always)]

--- a/src/interp/vm/disassemble.rs
+++ b/src/interp/vm/disassemble.rs
@@ -92,10 +92,7 @@ impl<'a, W: Write> Disassemble<W> for BytecodeReader<'a> {
     }
 }
 
-pub(super) fn bytecode_reader_write_single_inst<'a, W: Write>(
-    reader: &mut BytecodeReader<'a>,
-    w: &mut W,
-) {
+pub(super) fn bytecode_reader_write_single_inst<'a, W: Write>(reader: &mut BytecodeReader<'a>, w: &mut W) {
     if let Some(op) = reader.try_read_op() {
         write!(w, "{:06}\t{}", reader.cursor() - 1, op).unwrap();
 

--- a/src/interp/vm/index.rs
+++ b/src/interp/vm/index.rs
@@ -34,10 +34,7 @@ impl<'vm> VM<'vm> {
                 Pointer::Buffer(buf) => {
                     let buf = unsafe { &mut **buf };
                     let ptr = buf.bytes.offset_mut(index).as_mut_ptr();
-                    let value = Value::Pointer(Pointer::from_type_and_ptr(
-                        buf.ty.element_type().unwrap(),
-                        ptr as _,
-                    ));
+                    let value = Value::Pointer(Pointer::from_type_and_ptr(buf.ty.element_type().unwrap(), ptr as _));
                     self.stack.push(value);
                 }
                 _ => self.offset(value, index),
@@ -67,10 +64,8 @@ impl<'vm> VM<'vm> {
                     let raw = ptr.as_inner_raw();
                     let offset = unsafe { raw.add(index) };
 
-                    self.stack.push(Value::Pointer(Pointer::from_kind_and_ptr(
-                        ptr.kind(),
-                        offset,
-                    )))
+                    self.stack
+                        .push(Value::Pointer(Pointer::from_kind_and_ptr(ptr.kind(), offset)))
                 }
             },
             Value::Buffer(buf) => {

--- a/src/interp/vm/intrinsics.rs
+++ b/src/interp/vm/intrinsics.rs
@@ -54,8 +54,7 @@ impl<'vm> VM<'vm> {
                     check_mode: false,
                 };
 
-                let result =
-                    crate::driver::start_workspace(workspace_value.name.to_string(), build_options);
+                let result = crate::driver::start_workspace(workspace_value.name.to_string(), build_options);
 
                 let (output_file_str, ok) = if let Some(output_file) = &result.output_file {
                     (ustr(output_file.to_str().unwrap()), true)
@@ -66,10 +65,7 @@ impl<'vm> VM<'vm> {
                 let result_type = Type::Tuple(vec![Type::str(), Type::Bool]);
 
                 let result_value = Value::Buffer(Buffer::from_values(
-                    [
-                        Value::Buffer(Buffer::from_ustr(output_file_str)),
-                        Value::Bool(ok),
-                    ],
+                    [Value::Buffer(Buffer::from_ustr(output_file_str)), Value::Bool(ok)],
                     result_type,
                 ));
 

--- a/src/interp/vm/mod.rs
+++ b/src/interp/vm/mod.rs
@@ -153,11 +153,8 @@ impl<'vm> VM<'vm> {
 
                     let value = match const_ {
                         Value::ExternVariable(variable) => {
-                            let symbol = unsafe {
-                                self.interp
-                                    .ffi
-                                    .load_symbol(ustr(&variable.lib.path()), variable.name)
-                            };
+                            let symbol =
+                                unsafe { self.interp.ffi.load_symbol(ustr(&variable.lib.path()), variable.name) };
 
                             unsafe { Value::from_type_and_ptr(&variable.ty, *symbol as RawPointer) }
                         }
@@ -183,9 +180,7 @@ impl<'vm> VM<'vm> {
                         (Value::Uint(a), Value::Uint(b)) => self.stack.push(Value::Uint(a + b)),
                         (Value::F32(a), Value::F32(b)) => self.stack.push(Value::F32(a + b)),
                         (Value::F64(a), Value::F64(b)) => self.stack.push(Value::F64(a + b)),
-                        (Value::Pointer(a), Value::Int(b)) => {
-                            self.stack.push(Value::Pointer(unsafe { a.offset(*b) }))
-                        }
+                        (Value::Pointer(a), Value::Int(b)) => self.stack.push(Value::Pointer(unsafe { a.offset(*b) })),
                         _ => panic!(
                             "invalid types in binary operation `{}` : `{}` and `{}`",
                             stringify!(+),
@@ -211,9 +206,7 @@ impl<'vm> VM<'vm> {
                         (Value::Uint(a), Value::Uint(b)) => self.stack.push(Value::Uint(a - b)),
                         (Value::F32(a), Value::F32(b)) => self.stack.push(Value::F32(a - b)),
                         (Value::F64(a), Value::F64(b)) => self.stack.push(Value::F64(a - b)),
-                        (Value::Pointer(a), Value::Int(b)) => {
-                            self.stack.push(Value::Pointer(unsafe { a.offset(-*b) }))
-                        }
+                        (Value::Pointer(a), Value::Int(b)) => self.stack.push(Value::Pointer(unsafe { a.offset(-*b) })),
                         _ => panic!(
                             "invalid types in binary operation `{}` : `{}` and `{}`",
                             stringify!(-),
@@ -376,8 +369,7 @@ impl<'vm> VM<'vm> {
                     if self.frames.is_empty() {
                         break return_value;
                     } else {
-                        self.stack
-                            .truncate(frame.stack_slot - frame.func().ty.params.len());
+                        self.stack.truncate(frame.stack_slot - frame.func().ty.params.len());
                         self.frame = self.frames.last_mut() as _;
                         self.stack.push(return_value);
                     }
@@ -387,9 +379,10 @@ impl<'vm> VM<'vm> {
 
                     match self.stack.pop() {
                         Value::Function(addr) => {
-                            let function = self.interp.get_function(addr.id).unwrap_or_else(|| {
-                                panic!("couldn't find '{}' {:?}", addr.name, addr.id)
-                            });
+                            let function = self
+                                .interp
+                                .get_function(addr.id)
+                                .unwrap_or_else(|| panic!("couldn't find '{}' {:?}", addr.name, addr.id));
 
                             match function {
                                 FunctionValue::Orphan(function) => {
@@ -407,9 +400,7 @@ impl<'vm> VM<'vm> {
                                     let vm_ptr = self as *mut _;
                                     let interp_ptr = self.interp as *const _;
 
-                                    let result = unsafe {
-                                        self.interp.ffi.call(function, values, vm_ptr, interp_ptr)
-                                    };
+                                    let result = unsafe { self.interp.ffi.call(function, values, vm_ptr, interp_ptr) };
 
                                     self.stack.push(result);
                                 }
@@ -549,8 +540,7 @@ impl<'vm> VM<'vm> {
             self.stack.push(Value::default());
         }
 
-        self.frames
-            .push(StackFrame::<'vm>::new(function, stack_slot));
+        self.frames.push(StackFrame::<'vm>::new(function, stack_slot));
 
         self.frame = self.frames.last_mut() as _;
     }

--- a/src/interp/vm/value.rs
+++ b/src/interp/vm/value.rs
@@ -706,6 +706,7 @@ impl Value {
             Self::ExternVariable(v) => Ok(ConstValue::ExternVariable(ConstExternVariable {
                 name: v.name,
                 lib: Some(v.lib.clone()),
+                dylib: Some(v.lib.clone()),
                 ty: tcx.bound(v.ty, eval_span),
             })),
             Self::Pointer(_) => Err("pointer"),

--- a/src/lint/type_limits.rs
+++ b/src/lint/type_limits.rs
@@ -16,26 +16,14 @@ impl<'s> LintSess<'s> {
                     let (min, max) = int_type_range(*int_type);
 
                     if value < min || value > max {
-                        self.push_overflow_err(
-                            value,
-                            &const_.ty.display(self.tcx),
-                            min,
-                            max,
-                            const_.span,
-                        );
+                        self.push_overflow_err(value, &const_.ty.display(self.tcx), min, max, const_.span);
                     }
                 }
                 Type::Uint(uint_type) => {
                     let (_, max) = uint_type_range(*uint_type);
 
                     if value < 0 || value as u64 > max {
-                        self.push_overflow_err(
-                            value,
-                            &const_.ty.display(self.tcx),
-                            0,
-                            max,
-                            const_.span,
-                        );
+                        self.push_overflow_err(value, &const_.ty.display(self.tcx), 0, max, const_.span);
                     }
                 }
                 _ => (),
@@ -45,26 +33,14 @@ impl<'s> LintSess<'s> {
                     let (min, max) = int_type_range(*int_type);
 
                     if value > max as u64 {
-                        self.push_overflow_err(
-                            value,
-                            &const_.ty.display(self.tcx),
-                            min,
-                            max,
-                            const_.span,
-                        );
+                        self.push_overflow_err(value, &const_.ty.display(self.tcx), min, max, const_.span);
                     }
                 }
                 Type::Uint(uint_type) => {
                     let (min, max) = uint_type_range(*uint_type);
 
                     if value < min || value > max {
-                        self.push_overflow_err(
-                            value,
-                            &const_.ty.display(self.tcx),
-                            min,
-                            max,
-                            const_.span,
-                        );
+                        self.push_overflow_err(value, &const_.ty.display(self.tcx), min, max, const_.span);
                     }
                 }
                 _ => (),

--- a/src/main.rs
+++ b/src/main.rs
@@ -153,9 +153,7 @@ fn cli() {
                     emit_hir: false,
                     emit_bytecode: false,
                     diagnostic_options: DiagnosticOptions::DontEmit,
-                    codegen_options: CodegenOptions::Skip {
-                        emit_llvm_ir: false,
-                    },
+                    codegen_options: CodegenOptions::Skip { emit_llvm_ir: false },
                     include_paths: get_include_paths(&args.include_paths),
                     check_mode: true,
                 };
@@ -163,11 +161,7 @@ fn cli() {
                 let result = driver::start_workspace(name, build_options);
 
                 if args.diagnostics {
-                    ide::diagnostics(
-                        &result.workspace,
-                        result.tcx.as_ref(),
-                        result.cache.as_ref(),
-                    );
+                    ide::diagnostics(&result.workspace, result.tcx.as_ref(), result.cache.as_ref());
                 } else if let Some(offset) = args.hover_info {
                     ide::hover_info(&result.workspace, result.tcx.as_ref(), offset);
                 } else if let Some(offset) = args.goto_def {
@@ -233,8 +227,7 @@ fn print_err(msg: &str) {
 }
 
 fn get_include_paths(include_paths: &Option<String>) -> Vec<PathBuf> {
-    include_paths.as_ref().map_or_else(
-        || vec![],
-        |i| i.split(';').map(|s| PathBuf::from(s)).collect(),
-    )
+    include_paths
+        .as_ref()
+        .map_or_else(|| vec![], |i| i.split(';').map(|s| PathBuf::from(s)).collect())
 }

--- a/src/parse/attrs.rs
+++ b/src/parse/attrs.rs
@@ -13,10 +13,7 @@ impl Parser {
             let id = require!(self, Ident(_), "an identifier")?;
             let name = id.name();
 
-            let name_and_span = ast::NameAndSpan {
-                name,
-                span: id.span,
-            };
+            let name_and_span = ast::NameAndSpan { name, span: id.span };
 
             let value = if eat!(self, Eq) {
                 Some(Box::new(self.parse_expr()?))

--- a/src/parse/binding.rs
+++ b/src/parse/binding.rs
@@ -68,11 +68,8 @@ impl Parser {
         let lib = eat!(self, Str(_)).then(|| self.previous().name());
 
         let lib = if let Some(lib) = lib {
-            let lib = ast::ExternLibrary::try_from_str(
-                &lib,
-                RelativeTo::Path(self.module_info.dir()),
-                self.previous_span(),
-            )?;
+            let lib =
+                ast::ExternLibrary::try_from_str(&lib, RelativeTo::Path(self.module_info.dir()), self.previous_span())?;
 
             Some(lib)
         } else {
@@ -86,10 +83,7 @@ impl Parser {
         let id = require!(self, Ident(_), "an identifier")?;
         let name = id.name();
 
-        let name_and_span = ast::NameAndSpan {
-            name,
-            span: id.span,
-        };
+        let name_and_span = ast::NameAndSpan { name, span: id.span };
 
         let kind = if is_mutable {
             require!(self, Colon, ":")?;
@@ -112,7 +106,7 @@ impl Parser {
             }
         } else if eat!(self, Eq) {
             require!(self, Fn, "fn")?;
-            let sig = self.parse_function_sig(name, Some(lib.clone()))?;
+            let sig = self.parse_function_sig(name, true)?;
 
             ast::BindingKind::ExternFunction {
                 name: name_and_span,
@@ -151,10 +145,7 @@ impl Parser {
             attrs,
             visibility,
             kind: ast::BindingKind::Type {
-                name: ast::NameAndSpan {
-                    name,
-                    span: id.span,
-                },
+                name: ast::NameAndSpan { name, span: id.span },
                 type_expr: Box::new(type_expr),
             },
             span: start_span.to(self.previous_span()),

--- a/src/parse/binding.rs
+++ b/src/parse/binding.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::{ast::pattern::Pattern, common::path::RelativeTo, span::To, workspace::ModuleId};
+use crate::{ast::pattern::Pattern, span::To, workspace::ModuleId};
 
 impl Parser {
     pub fn try_parse_any_binding(
@@ -65,17 +65,6 @@ impl Parser {
     ) -> DiagnosticResult<ast::Binding> {
         let start_span = self.previous_span();
 
-        let lib = eat!(self, Str(_)).then(|| self.previous().name());
-
-        let lib = if let Some(lib) = lib {
-            let lib =
-                ast::ExternLibrary::try_from_str(&lib, RelativeTo::Path(self.module_info.dir()), self.previous_span())?;
-
-            Some(lib)
-        } else {
-            None
-        };
-
         require!(self, Let, "let")?;
 
         let is_mutable = eat!(self, Mut);
@@ -91,7 +80,6 @@ impl Parser {
 
             ast::BindingKind::ExternVariable {
                 name: name_and_span,
-                lib,
                 is_mutable,
                 type_expr: Box::new(type_expr),
             }
@@ -100,7 +88,6 @@ impl Parser {
 
             ast::BindingKind::ExternVariable {
                 name: name_and_span,
-                lib,
                 is_mutable,
                 type_expr: Box::new(type_expr),
             }
@@ -110,7 +97,6 @@ impl Parser {
 
             ast::BindingKind::ExternFunction {
                 name: name_and_span,
-                lib,
                 sig,
             }
         } else {

--- a/src/parse/expr.rs
+++ b/src/parse/expr.rs
@@ -54,11 +54,7 @@ impl Parser {
         self.decl_name_frames.push(decl_name);
 
         let expr = if is_stmt {
-            let attrs = if is!(self, Hash) {
-                self.parse_attrs()?
-            } else {
-                vec![]
-            };
+            let attrs = if is!(self, Hash) { self.parse_attrs()? } else { vec![] };
 
             let has_attrs = !attrs.is_empty();
 
@@ -69,10 +65,7 @@ impl Parser {
                         self.parse_logic_or()
                     } else {
                         Err(Diagnostic::error()
-                            .with_message(format!(
-                                "expected a binding, got `{}`",
-                                self.peek().lexeme
-                            ))
+                            .with_message(format!("expected a binding, got `{}`", self.peek().lexeme))
                             .with_label(Label::primary(self.span(), "unexpected token")))
                     }
                 }
@@ -127,16 +120,14 @@ impl Parser {
         while !eat!(self, CloseCurly) && !self.is_end() {
             self.skip_semicolons();
 
-            let expr = self
-                .parse_expr_res(Restrictions::STMT_EXPR)
-                .unwrap_or_else(|diag| {
-                    let span = self.previous_span();
+            let expr = self.parse_expr_res(Restrictions::STMT_EXPR).unwrap_or_else(|diag| {
+                let span = self.previous_span();
 
-                    self.cache.lock().diagnostics.push(diag);
-                    self.skip_until_recovery_point();
+                self.cache.lock().diagnostics.push(diag);
+                self.skip_until_recovery_point();
 
-                    ast::Ast::Error(ast::Empty { span })
-                });
+                ast::Ast::Error(ast::Empty { span })
+            });
 
             exprs.push(expr);
 
@@ -206,11 +197,7 @@ impl Parser {
     }
 
     pub fn parse_factor(&mut self) -> DiagnosticResult<Ast> {
-        parse_binary!(
-            self,
-            pattern = Star | FwSlash | Percent,
-            next_fn = Parser::parse_unary
-        )
+        parse_binary!(self, pattern = Star | FwSlash | Percent, next_fn = Parser::parse_unary)
     }
 
     pub fn parse_unary(&mut self) -> DiagnosticResult<Ast> {
@@ -308,10 +295,7 @@ impl Parser {
             }
         } else if eat!(self, Break | Continue | Return) {
             self.parse_terminator()?
-        } else if eat!(
-            self,
-            Nil | True | False | Int(_) | Float(_) | Str(_) | Char(_)
-        ) {
+        } else if eat!(self, Nil | True | False | Int(_) | Float(_) | Str(_) | Char(_)) {
             self.parse_literal()?
         } else if eat!(self, OpenParen) {
             let start_span = self.previous_span();
@@ -337,7 +321,7 @@ impl Parser {
             }
         } else if eat!(self, Fn) {
             let name = self.get_decl_name();
-            self.parse_function(name, None)?
+            self.parse_function(name, false)?
         } else if eat!(self, Struct) {
             self.parse_struct_type()?
         } else if eat!(self, Union) {
@@ -530,8 +514,7 @@ impl Parser {
 
         Ok(Ast::For(ast::For {
             iter_binding: ast::NameAndSpan::new(iter_ident.name(), iter_ident.span),
-            index_binding: iter_index_ident
-                .map(|ident| ast::NameAndSpan::new(ident.name(), ident.span)),
+            index_binding: iter_index_ident.map(|ident| ast::NameAndSpan::new(ident.name(), ident.span)),
             iterator,
             block,
             span: start_span.to(self.previous_span()),

--- a/src/parse/import.rs
+++ b/src/parse/import.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::{
-    common::path::{resolve_relative_path, try_resolve_relative_path, RelativeTo},
+    common::path::{maybe_resolve_relative_path, try_resolve_relative_path, RelativeTo},
     error::{
         diagnostic::{Diagnostic, Label},
         DiagnosticResult, SyntaxError,
@@ -35,7 +35,7 @@ impl Parser {
                 .join(PathBuf::from(path.trim_start_matches("~/")))
                 .with_extension(compiler_info::SOURCE_FILE_EXT);
 
-            let import_path = try_resolve_relative_path(&import_path, RelativeTo::Cwd, Some(path_token.span))?;
+            let import_path = try_resolve_relative_path(&import_path, &RelativeTo::Cwd, Some(path_token.span))?;
 
             self.check_import_path_is_under_root(&cache, &import_path, path_token.span)?;
 
@@ -45,7 +45,7 @@ impl Parser {
             // example: import("std")
             try_resolve_relative_path(
                 &compiler_info::std_module_root_file(),
-                RelativeTo::Cwd,
+                &RelativeTo::Cwd,
                 Some(path_token.span),
             )?
         } else if compiler_info::is_std_module_path_start(&path) {
@@ -59,7 +59,7 @@ impl Parser {
                 .join(trimmed_path)
                 .with_extension(compiler_info::SOURCE_FILE_EXT);
 
-            try_resolve_relative_path(&full_std_import_path, RelativeTo::Cwd, Some(path_token.span))?
+            try_resolve_relative_path(&full_std_import_path, &RelativeTo::Cwd, Some(path_token.span))?
         } else {
             // import relative to current dir
             // example: import("foo/bar")
@@ -87,12 +87,12 @@ impl Parser {
     fn search_for_import_path(&self, cache: &ParserCacheGuard, path: &Path, span: Span) -> DiagnosticResult<PathBuf> {
         let current_dir = self.module_info.dir();
 
-        if let Some(import_path) = resolve_relative_path(&path, RelativeTo::Path(current_dir)) {
+        if let Some(import_path) = maybe_resolve_relative_path(&path, &RelativeTo::Path(current_dir)) {
             self.check_import_path_is_under_root(&cache, &import_path, span)?;
             return Ok(import_path);
         } else {
             for include_path in cache.include_paths.iter() {
-                if let Some(path) = resolve_relative_path(&path, RelativeTo::Path(include_path)) {
+                if let Some(path) = maybe_resolve_relative_path(&path, &RelativeTo::Path(include_path)) {
                     return Ok(path);
                 }
             }

--- a/src/parse/import.rs
+++ b/src/parse/import.rs
@@ -35,8 +35,7 @@ impl Parser {
                 .join(PathBuf::from(path.trim_start_matches("~/")))
                 .with_extension(compiler_info::SOURCE_FILE_EXT);
 
-            let import_path =
-                try_resolve_relative_path(&import_path, RelativeTo::Cwd, Some(path_token.span))?;
+            let import_path = try_resolve_relative_path(&import_path, RelativeTo::Cwd, Some(path_token.span))?;
 
             self.check_import_path_is_under_root(&cache, &import_path, path_token.span)?;
 
@@ -60,11 +59,7 @@ impl Parser {
                 .join(trimmed_path)
                 .with_extension(compiler_info::SOURCE_FILE_EXT);
 
-            try_resolve_relative_path(
-                &full_std_import_path,
-                RelativeTo::Cwd,
-                Some(path_token.span),
-            )?
+            try_resolve_relative_path(&full_std_import_path, RelativeTo::Cwd, Some(path_token.span))?
         } else {
             // import relative to current dir
             // example: import("foo/bar")
@@ -74,10 +69,7 @@ impl Parser {
 
         let module_name = self.get_module_name_from_path(&cache, &absolute_import_path);
 
-        let module_info = PartialModuleInfo::new(
-            ustr(&module_name),
-            ustr(absolute_import_path.to_str().unwrap()),
-        );
+        let module_info = PartialModuleInfo::new(ustr(&module_name), ustr(absolute_import_path.to_str().unwrap()));
 
         spawn_parser(
             self.thread_pool.clone(),
@@ -92,12 +84,7 @@ impl Parser {
         }))
     }
 
-    fn search_for_import_path(
-        &self,
-        cache: &ParserCacheGuard,
-        path: &Path,
-        span: Span,
-    ) -> DiagnosticResult<PathBuf> {
+    fn search_for_import_path(&self, cache: &ParserCacheGuard, path: &Path, span: Span) -> DiagnosticResult<PathBuf> {
         let current_dir = self.module_info.dir();
 
         if let Some(import_path) = resolve_relative_path(&path, RelativeTo::Path(current_dir)) {

--- a/src/parse/literal.rs
+++ b/src/parse/literal.rs
@@ -62,13 +62,8 @@ impl Parser {
         }))
     }
 
-    pub fn parse_tuple_literal(
-        &mut self,
-        first_expr: Ast,
-        start_span: Span,
-    ) -> DiagnosticResult<Ast> {
-        let mut elements =
-            parse_delimited_list!(self, CloseParen, Comma, self.parse_expr()?, ", or )");
+    pub fn parse_tuple_literal(&mut self, first_expr: Ast, start_span: Span) -> DiagnosticResult<Ast> {
+        let mut elements = parse_delimited_list!(self, CloseParen, Comma, self.parse_expr()?, ", or )");
 
         elements.insert(0, first_expr);
 
@@ -78,11 +73,7 @@ impl Parser {
         }))
     }
 
-    pub fn parse_struct_literal(
-        &mut self,
-        type_expr: Option<Box<Ast>>,
-        start_span: Span,
-    ) -> DiagnosticResult<Ast> {
+    pub fn parse_struct_literal(&mut self, type_expr: Option<Box<Ast>>, start_span: Span) -> DiagnosticResult<Ast> {
         let fields = parse_delimited_list!(
             self,
             CloseCurly,

--- a/src/parse/mod.rs
+++ b/src/parse/mod.rs
@@ -9,7 +9,7 @@ mod postfix_expr;
 mod top_level;
 
 use crate::{
-    ast::{self, Ast, ExternLibrary},
+    ast::{self, Ast},
     error::{diagnostic::Diagnostic, DiagnosticResult, Diagnostics, SyntaxError},
     span::{EndPosition, Position, Span, To},
     token::{lexer::Lexer, Token, TokenKind::*},
@@ -186,9 +186,7 @@ impl Parser {
                 self.tokens = tokens;
                 self.parse_all_top_level(file_id)
             }
-            Err(diag) => {
-                ParserResult::LexerFailed(ast::Module::new(file_id, self.module_info), diag)
-            }
+            Err(diag) => ParserResult::LexerFailed(ast::Module::new(file_id, self.module_info), diag),
         }
     }
 

--- a/src/parse/pattern.rs
+++ b/src/parse/pattern.rs
@@ -1,7 +1,5 @@
 use super::*;
-use crate::ast::pattern::{
-    HybridPattern, NamePattern, Pattern, UnpackPattern, UnpackPatternKind, Wildcard,
-};
+use crate::ast::pattern::{HybridPattern, NamePattern, Pattern, UnpackPattern, UnpackPatternKind, Wildcard};
 use crate::error::SyntaxError;
 use crate::span::To;
 
@@ -103,13 +101,7 @@ impl Parser {
     fn parse_tuple_unpack(&mut self) -> DiagnosticResult<Pattern> {
         let start_span = self.previous_span();
 
-        let symbols = parse_delimited_list!(
-            self,
-            CloseParen,
-            Comma,
-            self.parse_name_pattern()?,
-            ", or )"
-        );
+        let symbols = parse_delimited_list!(self, CloseParen, Comma, self.parse_name_pattern()?, ", or )");
 
         let unpack = UnpackPattern {
             symbols,

--- a/src/parse/postfix_expr.rs
+++ b/src/parse/postfix_expr.rs
@@ -48,7 +48,7 @@ impl Parser {
             } else if eat!(self, Fn) {
                 let start_span = expr.span();
 
-                let fn_arg = self.parse_function(ustr("_"), None)?;
+                let fn_arg = self.parse_function(ustr(""), false)?;
                 let span = start_span.to(self.previous_span());
 
                 match &mut expr {
@@ -167,12 +167,7 @@ impl Parser {
 
             OpenParen => self.parse_call(expr)?,
 
-            _ => {
-                return Err(SyntaxError::expected(
-                    self.span(),
-                    "an identifier, number or *",
-                ))
-            }
+            _ => return Err(SyntaxError::expected(self.span(), "an identifier, number or *")),
         };
 
         Ok(expr)

--- a/src/parse/top_level.rs
+++ b/src/parse/top_level.rs
@@ -20,10 +20,7 @@ impl Parser {
                     // Especially since the language is expression-based.
                     if let Err(_) = require!(self, Semicolon, ";") {
                         let span = Parser::get_missing_delimiter_span(self.previous_span());
-                        self.cache
-                            .lock()
-                            .diagnostics
-                            .push(SyntaxError::expected(span, ";"));
+                        self.cache.lock().diagnostics.push(SyntaxError::expected(span, ";"));
                         self.skip_until_recovery_point();
                     }
                 }
@@ -40,11 +37,7 @@ impl Parser {
     }
 
     pub fn parse_top_level(&mut self, module: &mut ast::Module) -> DiagnosticResult<()> {
-        let attrs = if is!(self, Hash) {
-            self.parse_attrs()?
-        } else {
-            vec![]
-        };
+        let attrs = if is!(self, Hash) { self.parse_attrs()? } else { vec![] };
 
         let has_attrs = !attrs.is_empty();
 

--- a/src/span/mod.rs
+++ b/src/span/mod.rs
@@ -11,11 +11,7 @@ pub struct Span {
 
 impl Span {
     pub fn new(file_id: FileId, start: Position, end: EndPosition) -> Self {
-        Self {
-            file_id,
-            start,
-            end,
-        }
+        Self { file_id, start, end }
     }
 
     pub fn initial(file_id: FileId) -> Self {
@@ -76,11 +72,7 @@ pub struct Position {
 
 impl Position {
     pub fn new(index: usize, line: u32, column: u16) -> Self {
-        Self {
-            index,
-            line,
-            column,
-        }
+        Self { index, line, column }
     }
 
     pub fn initial() -> Self {

--- a/src/token/cursor.rs
+++ b/src/token/cursor.rs
@@ -52,13 +52,7 @@ impl Cursor {
     }
 
     pub fn span(&self) -> Span {
-        Span::new(
-            self.file_id,
-            self.start,
-            EndPosition {
-                index: self.end.index,
-            },
-        )
+        Span::new(self.file_id, self.start, EndPosition { index: self.end.index })
     }
 
     pub fn end_span(&self) -> Span {
@@ -69,9 +63,7 @@ impl Cursor {
                 line: self.start.line, // FIXME: this is the wrong line...
                 column: self.start.column,
             },
-            EndPosition {
-                index: self.end.index,
-            },
+            EndPosition { index: self.end.index },
         )
     }
 }

--- a/src/token/lexer.rs
+++ b/src/token/lexer.rs
@@ -68,13 +68,8 @@ impl<'lx> Lexer<'lx> {
                             self.eat_token()?
                         } else {
                             return Err(Diagnostic::error()
-                                .with_message(
-                                    "shebang is only supported on the first line of the file",
-                                )
-                                .with_label(Label::primary(
-                                    self.cursor.span(),
-                                    "invalid shebang",
-                                )));
+                                .with_message("shebang is only supported on the first line of the file")
+                                .with_label(Label::primary(self.cursor.span(), "invalid shebang")));
                         }
                     } else {
                         Hash
@@ -313,21 +308,13 @@ impl<'lx> Lexer<'lx> {
                     StrFlavor::Normal if contents.contains('\n') => {
                         return Err(Diagnostic::error()
                             .with_message("string cannot contain newline characters")
-                            .with_label(Label::primary(
-                                self.cursor.span(),
-                                "cannot contain newline",
-                            ))
-                            .with_note(
-                                "use a multiline string instead, example: \"\"\"your string\"\"\"",
-                            ))
+                            .with_label(Label::primary(self.cursor.span(), "cannot contain newline"))
+                            .with_note("use a multiline string instead, example: \"\"\"your string\"\"\""))
                     }
                     StrFlavor::Char if contents.len() != 1 => {
                         return Err(Diagnostic::error()
                             .with_message("character literal must be one character long")
-                            .with_label(Label::primary(
-                                self.cursor.span(),
-                                "not one character long",
-                            )))
+                            .with_label(Label::primary(self.cursor.span(), "not one character long")))
                     }
                     _ => (),
                 }
@@ -404,10 +391,7 @@ impl<'lx> Lexer<'lx> {
         while !self.is_eof() {
             let char = self.peek();
 
-            if ('0'..='9').contains(&char)
-                || ('A'..='F').contains(&char)
-                || ('a'..='f').contains(&char)
-            {
+            if ('0'..='9').contains(&char) || ('A'..='F').contains(&char) || ('a'..='f').contains(&char) {
                 hex_value.push(char);
                 self.bump();
             } else {

--- a/src/types/align_of.rs
+++ b/src/types/align_of.rs
@@ -13,16 +13,11 @@ impl AlignOf for Type {
             Type::Float(ty) => ty.align_of(word_size),
             Type::Pointer(..) | Type::Function(..) => word_size,
             Type::Array(ty, ..) => ty.align_of(word_size),
-            Type::Infer(_, InferType::PartialTuple(elems)) | Type::Tuple(elems) => {
-                StructType::temp(
-                    elems
-                        .iter()
-                        .map(|t| StructTypeField::temp(t.clone()))
-                        .collect(),
-                    StructTypeKind::Struct,
-                )
-                .align_of(word_size)
-            }
+            Type::Infer(_, InferType::PartialTuple(elems)) | Type::Tuple(elems) => StructType::temp(
+                elems.iter().map(|t| StructTypeField::temp(t.clone())).collect(),
+                StructTypeKind::Struct,
+            )
+            .align_of(word_size),
             Type::Struct(s) => s.align_of(word_size),
             Type::Infer(_, InferType::PartialStruct(partial_struct)) => {
                 let mut max_align: usize = 1;

--- a/src/types/display.rs
+++ b/src/types/display.rs
@@ -32,17 +32,13 @@ impl Display for Type {
                     FloatType::Float => "float",
                 }
                 .to_string(),
-                Type::Pointer(ty, is_mutable) =>
-                    format!("*{}{}", if *is_mutable { "mut " } else { "" }, ty),
+                Type::Pointer(ty, is_mutable) => format!("*{}{}", if *is_mutable { "mut " } else { "" }, ty),
                 Type::Function(func) => func.to_string(),
                 Type::Array(inner, size) => format!("[{}]{}", size, inner),
                 Type::Slice(inner) => format!("[]{}", inner),
                 Type::Tuple(tys) | Type::Infer(_, InferType::PartialTuple(tys)) => format!(
                     "({})",
-                    tys.iter()
-                        .map(|t| t.to_string())
-                        .collect::<Vec<String>>()
-                        .join(", ")
+                    tys.iter().map(|t| t.to_string()).collect::<Vec<String>>().join(", ")
                 ),
                 Type::Struct(ty) => ty.to_string(),
                 Type::Type(_) | Type::AnyType => "type".to_string(),

--- a/src/types/is_sized.rs
+++ b/src/types/is_sized.rs
@@ -23,13 +23,9 @@ impl IsSized for Type {
             | Type::Infer(_, InferType::AnyInt)
             | Type::Infer(_, InferType::AnyFloat) => true,
 
-            Type::Module(_) | Type::Type(_) | Type::AnyType | Type::Var(_) | Type::Slice(..) => {
-                false
-            }
+            Type::Module(_) | Type::Type(_) | Type::AnyType | Type::Var(_) | Type::Slice(..) => false,
 
-            Type::Infer(_, InferType::PartialTuple(elems)) | Type::Tuple(elems) => {
-                elems.iter().all(|e| e.is_sized())
-            }
+            Type::Infer(_, InferType::PartialTuple(elems)) | Type::Tuple(elems) => elems.iter().all(|e| e.is_sized()),
 
             Type::Struct(s) => s.fields.iter().all(|f| f.ty.is_sized()),
 

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -108,6 +108,12 @@ pub struct FunctionType {
     pub kind: FunctionTypeKind,
 }
 
+impl FunctionType {
+    pub fn is_variadic(&self) -> bool {
+        self.varargs.is_some()
+    }
+}
+
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct FunctionTypeParam {
     pub name: Ustr,

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -5,7 +5,6 @@ pub mod offset_of;
 pub mod size_of;
 
 use crate::{
-    ast::ExternLibrary,
     define_id_type,
     span::Span,
     workspace::{BindingId, ModuleId},
@@ -124,7 +123,7 @@ pub struct FunctionTypeVarargs {
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum FunctionTypeKind {
     Orphan,
-    Extern { lib: Option<ExternLibrary> },
+    Extern,
 }
 
 impl FunctionTypeKind {
@@ -155,10 +154,7 @@ impl StructType {
     }
 
     pub fn find_field_full(&self, field: Ustr) -> Option<(usize, &StructTypeField)> {
-        self.fields
-            .iter()
-            .enumerate()
-            .find(|(_, f)| f.name == field)
+        self.fields.iter().enumerate().find(|(_, f)| f.name == field)
     }
 }
 
@@ -274,20 +270,14 @@ impl From<Type> for String {
 impl Type {
     pub fn as_inner(&self) -> &Type {
         match self {
-            Type::Pointer(inner, _)
-            | Type::Array(inner, _)
-            | Type::Slice(inner)
-            | Type::Type(inner) => inner,
+            Type::Pointer(inner, _) | Type::Array(inner, _) | Type::Slice(inner) | Type::Type(inner) => inner,
             _ => panic!("type {} doesn't have an inner type", self),
         }
     }
 
     pub fn into_inner(self) -> Type {
         match self {
-            Type::Pointer(inner, _)
-            | Type::Array(inner, _)
-            | Type::Slice(inner)
-            | Type::Type(inner) => *inner,
+            Type::Pointer(inner, _) | Type::Array(inner, _) | Type::Slice(inner) | Type::Type(inner) => *inner,
             _ => panic!("type {} doesn't have an inner type", self),
         }
     }

--- a/src/types/offset_of.rs
+++ b/src/types/offset_of.rs
@@ -22,16 +22,11 @@ impl OffsetOf for Type {
                 1 => word_size,
                 _ => panic!("{}", index),
             },
-            Type::Infer(_, InferType::PartialTuple(elems)) | Type::Tuple(elems) => {
-                StructType::temp(
-                    elems
-                        .iter()
-                        .map(|t| StructTypeField::temp(t.clone()))
-                        .collect(),
-                    StructTypeKind::Struct,
-                )
-                .offset_of(index, word_size)
-            }
+            Type::Infer(_, InferType::PartialTuple(elems)) | Type::Tuple(elems) => StructType::temp(
+                elems.iter().map(|t| StructTypeField::temp(t.clone())).collect(),
+                StructTypeKind::Struct,
+            )
+            .offset_of(index, word_size),
             Type::Struct(s) => s.offset_of(index, word_size),
             Type::Infer(_, InferType::PartialStruct(partial_struct)) => {
                 let mut offset = 0;
@@ -63,12 +58,7 @@ impl OffsetOf for StructType {
 
                 offset
             }
-            StructTypeKind::PackedStruct => self
-                .fields
-                .iter()
-                .take(index)
-                .map(|f| f.ty.size_of(word_size))
-                .sum(),
+            StructTypeKind::PackedStruct => self.fields.iter().take(index).map(|f| f.ty.size_of(word_size)).sum(),
             StructTypeKind::Union => 0,
         }
     }

--- a/src/types/size_of.rs
+++ b/src/types/size_of.rs
@@ -20,16 +20,11 @@ impl SizeOf for Type {
             },
             Type::Function(..) => word_size,
             Type::Array(ty, len) => ty.size_of(word_size) * len,
-            Type::Infer(_, InferType::PartialTuple(elems)) | Type::Tuple(elems) => {
-                StructType::temp(
-                    elems
-                        .iter()
-                        .map(|t| StructTypeField::temp(t.clone()))
-                        .collect(),
-                    StructTypeKind::Struct,
-                )
-                .size_of(word_size)
-            }
+            Type::Infer(_, InferType::PartialTuple(elems)) | Type::Tuple(elems) => StructType::temp(
+                elems.iter().map(|t| StructTypeField::temp(t.clone())).collect(),
+                StructTypeKind::Struct,
+            )
+            .size_of(word_size),
             Type::Struct(s) => s.size_of(word_size),
             Type::Infer(_, InferType::PartialStruct(partial_struct)) => {
                 let mut offset = 0;
@@ -102,16 +97,9 @@ impl SizeOf for StructType {
 
                 offset
             }
-            StructTypeKind::PackedStruct => {
-                self.fields.iter().map(|f| f.ty.size_of(word_size)).sum()
-            }
+            StructTypeKind::PackedStruct => self.fields.iter().map(|f| f.ty.size_of(word_size)).sum(),
             StructTypeKind::Union => {
-                let max_size = self
-                    .fields
-                    .iter()
-                    .map(|f| f.ty.size_of(word_size))
-                    .max()
-                    .unwrap_or(0);
+                let max_size = self.fields.iter().map(|f| f.ty.size_of(word_size)).max().unwrap_or(0);
 
                 let align = self.align_of(word_size);
 

--- a/src/workspace/compiler_info.rs
+++ b/src/workspace/compiler_info.rs
@@ -17,11 +17,7 @@ pub fn is_std_module_path_start(path: &str) -> bool {
 
 pub fn std_module_root_dir() -> PathBuf {
     fn root_dir() -> PathBuf {
-        std::env::current_exe()
-            .unwrap()
-            .parent()
-            .unwrap()
-            .to_path_buf()
+        std::env::current_exe().unwrap().parent().unwrap().to_path_buf()
     }
 
     let mut dir = root_dir();

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -117,8 +117,7 @@ impl BindingInfo {
     #[inline]
     #[allow(unused)]
     pub fn is_is_implicit_it_fn_parameter(&self) -> bool {
-        self.flags
-            .contains(BindingInfoFlags::IS_IMPLICIT_IT_FN_PARAMETER)
+        self.flags.contains(BindingInfoFlags::IS_IMPLICIT_IT_FN_PARAMETER)
     }
 
     #[inline]
@@ -189,12 +188,7 @@ bitflags! {
 }
 
 impl Workspace {
-    pub fn new(
-        name: String,
-        build_options: BuildOptions,
-        root_dir: PathBuf,
-        std_dir: PathBuf,
-    ) -> Self {
+    pub fn new(name: String, build_options: BuildOptions, root_dir: PathBuf, std_dir: PathBuf) -> Self {
         Self {
             name,
             diagnostics: Diagnostics::new(),
@@ -212,11 +206,7 @@ impl Workspace {
             DiagnosticOptions::Emit { no_color } => {
                 emit_diagnostics(
                     &self.diagnostics,
-                    if *no_color {
-                        ColorMode::Never
-                    } else {
-                        ColorMode::Always
-                    },
+                    if *no_color { ColorMode::Never } else { ColorMode::Always },
                 );
             }
             DiagnosticOptions::DontEmit => (),


### PR DESCRIPTION
Added:
`#[lib = "..."]` : Specifies the library to link to
`#[dylib = "..."]` : Specifies the dynamic library to link to. This is mainly used when you use function both in the interpreter and when compiled.
`#[link_name = "..."]` : The underlying symbol to link to.