### PR TITLE
Remove dot struct prefix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,5 +24,6 @@ vm.out
 dist
 examples/**/out
 docs/demo
+docs/static
 local_resources
 hir.pretty.chl

--- a/docs/demo.chl
+++ b/docs/demo.chl
@@ -343,7 +343,13 @@ fn structs = {
     print_point(my_point);
 
     // Anonymous initialization
-    let my_point = .{ x: 1, y: 2 };
+    let my_point = { x: 1, y: 2 };
+    print_point(my_point);
+
+    // If a value is the same name as an identifer, you can omit the value as a shorthand
+    let x = 3;
+    let y = 4;
+    let my_point = { x, y };
     print_point(my_point);
 };
 
@@ -392,12 +398,12 @@ fn binding_patterns = {
     std.c.printf("%d\n".data, x);
 
     // Struct unpack:
-    let { x, y } = .{ x: 40, y: 33 };
+    let { x, y } = { x: 40, y: 33 };
     std.c.printf("%d %d\n".data, x, y);
 
     // This pattern's sub-patterns are named, so it is order-free.
     // Here we unpack the `y` field, even though it is the second one in the struct. 
-    let { y } = .{ x: 40, y: 33 };
+    let { y } = { x: 40, y: 33 };
     std.c.printf("%d\n".data, x);
 
     // Module unpack:
@@ -420,13 +426,13 @@ fn binding_patterns = {
 
     hello();
 
-    let { * } = .{ a: 3, b: 4 };
+    let { * } = { a: 3, b: 4 };
     //    ^---- `a` and `b` come from here
 
     std.c.printf("a=%d b=%d\n".data, a, b);
 
     // Wildcard patterns can be partially applied
-    let { a, * } = .{ a: 8, b: 99 };
+    let { a, * } = { a: 8, b: 99 };
     //       ^---- only `b` is unpacked here
 
     std.c.printf("a=%d b=%d\n".data, a, b);

--- a/examples/playground/src/main.chl
+++ b/examples/playground/src/main.chl
@@ -1,19 +1,3 @@
 fn main = {
     println("Hello World");
-    let unit = {};
-
-    type Point = struct { x: int, y: int };
-    type Foo = struct { quox: int };
-
-    let point = Point { x: 1, y: 2 };
-    std.c.printf("x=%d y=%d\n".data, point.x, point.y);
-
-    let foo: Foo = { quox: 1 };
-    std.c.printf("foo.quox=%d\n".data, foo.quox);
-
-    let bar = { foo };
-    std.c.printf("bar.quox=%d\n".data, bar.quox);
-
-    let baz = { bar, };
-    std.c.printf("baz.bar.quox=%d\n".data, baz.bar.quox);
 };

--- a/examples/playground/src/main.chl
+++ b/examples/playground/src/main.chl
@@ -2,7 +2,7 @@ fn main = {
     println("Hello World");
     let unit = {};
 
-    let point = .{ x: 1, y: 2 };
+    let point = { x: 1, y: 2 };
     std.c.printf("x=%d y=%d\n".data, point.x, point.y);
 
     let foo = .{ bar: 1 };

--- a/examples/playground/src/main.chl
+++ b/examples/playground/src/main.chl
@@ -1,1 +1,16 @@
-fn main = println("Hello World");
+fn main = {
+    println("Hello World");
+    let unit = {};
+
+    let point = .{ x: 1, y: 2 };
+    std.c.printf("x=%d y=%d\n".data, point.x, point.y);
+
+    let foo = .{ bar: 1 };
+    std.c.printf("foo.bar=%d\n".data, foo.bar);
+
+    let bar = .{ foo };
+    std.c.printf("bar.foo=%d\n".data, bar.foo);
+
+    let baz = .{ bar, };
+    std.c.printf("baz.bar=%d\n".data, baz.bar);
+};

--- a/examples/playground/src/main.chl
+++ b/examples/playground/src/main.chl
@@ -2,15 +2,18 @@ fn main = {
     println("Hello World");
     let unit = {};
 
-    let point = { x: 1, y: 2 };
+    type Point = struct { x: int, y: int };
+    type Foo = struct { quox: int };
+
+    let point = Point { x: 1, y: 2 };
     std.c.printf("x=%d y=%d\n".data, point.x, point.y);
 
-    let foo = .{ bar: 1 };
-    std.c.printf("foo.bar=%d\n".data, foo.bar);
+    let foo: Foo = { quox: 1 };
+    std.c.printf("foo.quox=%d\n".data, foo.quox);
 
-    let bar = .{ foo };
-    std.c.printf("bar.foo=%d\n".data, bar.foo);
+    let bar = { foo };
+    std.c.printf("bar.quox=%d\n".data, bar.quox);
 
-    let baz = .{ bar, };
-    std.c.printf("baz.bar=%d\n".data, baz.bar);
+    let baz = { bar, };
+    std.c.printf("baz.bar.quox=%d\n".data, baz.bar.quox);
 };

--- a/src/backend/llvm/ty.rs
+++ b/src/backend/llvm/ty.rs
@@ -5,6 +5,7 @@ use super::{
 use crate::{
     infer::normalize::Normalize,
     types::{size_of::SizeOf, *},
+    workspace::BindingId,
 };
 use inkwell::{
     types::{AnyType, BasicMetadataTypeEnum, BasicType, BasicTypeEnum, PointerType},
@@ -76,7 +77,7 @@ impl<'g, 'ctx> IntoLlvmType<'g, 'ctx> for Type {
                 )
                 .into(),
             Type::Struct(struct_ty) => {
-                let struct_type = if struct_ty.name.is_empty() {
+                let struct_type = if struct_ty.binding_id == BindingId::unknown() {
                     generator.create_anonymous_struct_type(struct_ty)
                 } else {
                     generator.get_or_create_named_struct_type(struct_ty)

--- a/src/parse/expr.rs
+++ b/src/parse/expr.rs
@@ -271,21 +271,9 @@ impl Parser {
         } else if eat!(self, For) {
             self.parse_for()?
         } else if is!(self, OpenCurly) {
-            self.parse_block_expr()?
+            self.parse_struct_literal_or_parse_block_expr()?
         } else if eat!(self, OpenBracket) {
             self.parse_array_type_or_literal()?
-        } else if eat!(self, Dot) {
-            let start_span = self.previous_span();
-
-            if eat!(self, OpenCurly) {
-                // anonymous struct literal
-                self.parse_struct_literal(None, start_span)?
-            } else {
-                return Err(SyntaxError::expected(
-                    self.span(),
-                    &format!("{{, got `{}`", self.peek().lexeme),
-                ));
-            }
         } else if eat!(self, Break | Continue | Return) {
             self.parse_terminator()?
         } else if eat!(self, Nil | True | False | Int(_) | Float(_) | Str(_) | Char(_)) {

--- a/src/parse/postfix_expr.rs
+++ b/src/parse/postfix_expr.rs
@@ -8,9 +8,8 @@ use ustr::ustr;
 impl Parser {
     pub fn parse_postfix_expr(&mut self, mut expr: Ast) -> DiagnosticResult<Ast> {
         // named struct literal
-        if !self.restrictions.contains(Restrictions::NO_STRUCT_LITERAL) && eat!(self, OpenCurly) {
-            let start_span = expr.span();
-            return self.parse_struct_literal(Some(Box::new(expr)), start_span);
+        if !self.restrictions.contains(Restrictions::NO_STRUCT_LITERAL) && is!(self, OpenCurly) {
+            return self.parse_struct_literal(Some(Box::new(expr)));
         }
 
         if self.restrictions.contains(Restrictions::STMT_EXPR) {


### PR DESCRIPTION
This PR removes the need to disambiguate anonymous struct literals with a `.`

Previous syntax: `let foo = .{ bar: 1, baz: "baz" }`
New syntax: `let foo = { bar: 1, baz: "baz" }`

Although this introduces other ambiguities which will be listed below, I think this is a really good tradeoff.
Some cases where it won't be obvious to the user:
`{}` - This is an empty block, not an empty struct
`{ foo }` - This is a block with a single identifier expression `foo`
`{ foo, }` - This is a struct with a single field `foo`, where is assigned to the value `foo` (shorthand initlalization)

The last case especially is similar to the case with single element tuples, so we could argue that this change makes the language more consistent with its syntax choices. Also, this change makes struct literals be symmetric to struct unpack patterns.