### PR TITLE
Remove partial inference types

### DIFF
--- a/src/check/pattern.rs
+++ b/src/check/pattern.rs
@@ -12,20 +12,15 @@ use crate::{
     },
     error::{
         diagnostic::{Diagnostic, Label},
-        DiagnosticResult, SyntaxError,
+        DiagnosticResult, SyntaxError, TypeError,
     },
     hir,
-    infer::{
-        display::{DisplayType, OrReportErr},
-        normalize::Normalize,
-        unify::UnifyType,
-    },
+    infer::{display::DisplayType, normalize::Normalize},
     span::Span,
-    types::{InferType, PartialStructType, Type, TypeId},
+    types::{Type, TypeId},
     workspace::{BindingId, BindingInfoFlags, BindingInfoKind, ModuleId, PartialBindingInfo, ScopeLevel},
 };
-use indexmap::IndexMap;
-use ustr::{ustr, Ustr};
+use ustr::{ustr, Ustr, UstrMap};
 
 impl<'s> CheckSess<'s> {
     pub fn get_global_binding_id(&self, module_id: ModuleId, name: Ustr) -> Option<BindingId> {
@@ -354,10 +349,6 @@ impl<'s> CheckSess<'s> {
     ) -> DiagnosticResult<()> {
         match ty.normalize(&self.tcx).maybe_deref_once() {
             Type::Module(module_id) => {
-                // if let Some(b) = statements.last().map(|node| node.as_binding()).flatten() {
-                //     statements.pop();
-                // }
-
                 self.check_module_by_id(module_id)?;
 
                 // println!(
@@ -368,7 +359,16 @@ impl<'s> CheckSess<'s> {
 
                 let module_bindings = self.global_scopes.get(&module_id).unwrap().bindings.clone();
 
+                let mut unpacked_names = UstrMap::default();
+
                 for pattern in unpack_pattern.sub_patterns.iter() {
+                    if let Some(already_unpacked_span) = unpacked_names.insert(pattern.name(), pattern.span()) {
+                        return Err(Diagnostic::error()
+                            .with_message(format!("symbol `{}` has already been unpacked", pattern.name()))
+                            .with_label(Label::primary(pattern.span(), "duplicate unpack"))
+                            .with_label(Label::secondary(already_unpacked_span, "already unpacked here")));
+                    }
+
                     match pattern {
                         StructUnpackSubPattern::Name(pattern) => {
                             let caller_info = CallerInfo {
@@ -439,13 +439,8 @@ impl<'s> CheckSess<'s> {
                             continue;
                         }
 
-                        if unpack_pattern
-                            .sub_patterns
-                            .iter()
-                            .find(|p| binding_info.name == p.name())
-                            .is_some()
-                        {
-                            // skip explicitly unpacked fields
+                        // skip explicitly unpacked bindings
+                        if unpacked_names.contains_key(&binding_info.name) {
                             continue;
                         }
 
@@ -464,138 +459,117 @@ impl<'s> CheckSess<'s> {
                         statements.push(binding);
                     }
                 }
+
+                Ok(())
             }
-            type_kind => {
-                let partial_struct = PartialStructType(IndexMap::from_iter(
-                    unpack_pattern
-                        .sub_patterns
-                        .iter()
-                        .map(|pattern| (pattern.name(), self.tcx.var(pattern.span()).as_kind())),
-                ));
-
-                let partial_struct_ty = self.tcx.partial_struct(partial_struct.clone(), unpack_pattern.span);
-
-                ty.unify(&partial_struct_ty, &mut self.tcx).or_report_err(
-                    &self.tcx,
-                    &partial_struct_ty,
-                    Some(unpack_pattern.span),
-                    &ty,
-                    ty_origin_span,
-                )?;
+            Type::Struct(struct_type) => {
+                let mut unpacked_names = UstrMap::default();
 
                 for (index, pattern) in unpack_pattern.sub_patterns.iter().enumerate() {
                     let name = pattern.name();
+                    let span = pattern.span();
 
-                    let ty = self.tcx.bound(partial_struct[&name].clone(), pattern.span());
+                    if let Some(already_unpacked_span) = unpacked_names.insert(name, span) {
+                        return Err(Diagnostic::error()
+                            .with_message(format!("field `{}` has already been unpacked", name))
+                            .with_label(Label::primary(span, "duplicate unpack"))
+                            .with_label(Label::secondary(already_unpacked_span, "already unpacked here")));
+                    } else if let Some(field) = struct_type.field(name) {
+                        let ty = self.tcx.bound(field.ty.clone(), span);
 
-                    let field_value = match value.as_const_value() {
-                        Some(const_value) if !pattern.is_mutable() => hir::Node::Const(hir::Const {
-                            value: const_value.as_struct().unwrap().get(&name).unwrap().clone().value,
-                            ty,
-                            span: pattern.span(),
-                        }),
-                        _ => hir::Node::MemberAccess(hir::MemberAccess {
-                            value: Box::new(value.clone()),
-                            member_name: name,
-                            member_index: index as _,
-                            ty,
-                            span: pattern.span(),
-                        }),
-                    };
+                        let field_value = match value.as_const_value() {
+                            Some(const_value) if !pattern.is_mutable() => hir::Node::Const(hir::Const {
+                                value: const_value.as_struct().unwrap().get(&name).unwrap().clone().value,
+                                ty,
+                                span,
+                            }),
+                            _ => hir::Node::MemberAccess(hir::MemberAccess {
+                                value: Box::new(value.clone()),
+                                member_name: name,
+                                member_index: index as _,
+                                ty,
+                                span,
+                            }),
+                        };
 
-                    let (_, bound_node) = match pattern {
-                        StructUnpackSubPattern::Name(pattern) => self.bind_name_pattern(
-                            env,
-                            pattern,
-                            visibility,
-                            ty,
-                            Some(field_value),
-                            kind,
-                            flags | BindingInfoFlags::TYPE_WAS_INFERRED,
-                        )?,
-                        StructUnpackSubPattern::NameAndPattern(_, pattern) => self.bind_pattern(
-                            env,
-                            pattern,
-                            visibility,
-                            ty,
-                            Some(field_value),
-                            kind,
-                            ty_origin_span,
-                            flags | BindingInfoFlags::TYPE_WAS_INFERRED,
-                        )?,
-                    };
+                        let (_, bound_node) = match pattern {
+                            StructUnpackSubPattern::Name(pattern) => self.bind_name_pattern(
+                                env,
+                                pattern,
+                                visibility,
+                                ty,
+                                Some(field_value),
+                                kind,
+                                flags | BindingInfoFlags::TYPE_WAS_INFERRED,
+                            )?,
+                            StructUnpackSubPattern::NameAndPattern(_, pattern) => self.bind_pattern(
+                                env,
+                                pattern,
+                                visibility,
+                                ty,
+                                Some(field_value),
+                                kind,
+                                ty_origin_span,
+                                flags | BindingInfoFlags::TYPE_WAS_INFERRED,
+                            )?,
+                        };
 
-                    statements.push(bound_node);
+                        statements.push(bound_node);
+                    } else {
+                        return Err(TypeError::invalid_struct_field(
+                            pattern.span(),
+                            pattern.name(),
+                            struct_type.display(&self.tcx),
+                        ));
+                    }
                 }
 
                 if let Some(wildcard) = &unpack_pattern.wildcard {
-                    match type_kind {
-                        Type::Struct(struct_ty) => {
-                            for (index, field) in struct_ty.fields.iter().enumerate() {
-                                if unpack_pattern
-                                    .sub_patterns
-                                    .iter()
-                                    .find(|p| field.name == p.name())
-                                    .is_some()
-                                {
-                                    // skip explicitly unpacked fields
-                                    continue;
-                                }
-
-                                let ty = self.tcx.bound(field.ty.clone(), field.span);
-
-                                let field_value = match value.as_const_value() {
-                                    Some(const_value) => hir::Node::Const(hir::Const {
-                                        value: const_value.as_struct().unwrap().get(&field.name).unwrap().value.clone(),
-                                        ty,
-                                        span: field.span,
-                                    }),
-                                    None => hir::Node::MemberAccess(hir::MemberAccess {
-                                        value: Box::new(value.clone()),
-                                        member_name: field.name,
-                                        member_index: index as _,
-                                        ty,
-                                        span: field.span,
-                                    }),
-                                };
-
-                                let (_, bound_node) = self.bind_name(
-                                    env,
-                                    field.name,
-                                    visibility,
-                                    ty,
-                                    Some(field_value),
-                                    false,
-                                    kind,
-                                    wildcard.span,
-                                    flags - BindingInfoFlags::IS_USER_DEFINED,
-                                )?;
-
-                                statements.push(bound_node);
-                            }
+                    for (index, field) in struct_type.fields.iter().enumerate() {
+                        // skip explicitly unpacked fields
+                        if unpacked_names.contains_key(&field.name) {
+                            continue;
                         }
-                        Type::Infer(_, InferType::PartialStruct(_)) => {
-                            return Err(Diagnostic::error()
-                                .with_message(format!(
-                                    "cannot use wildcard unpack on partial struct type - {}",
-                                    type_kind.display(&self.tcx)
-                                ))
-                                .with_label(Label::primary(wildcard.span, "illegal wildcard unpack")))
-                        }
-                        _ => {
-                            return Err(Diagnostic::error()
-                                .with_message(format!(
-                                    "cannot use wildcard unpack on partial tuple type - {}",
-                                    type_kind.display(&self.tcx)
-                                ))
-                                .with_label(Label::primary(wildcard.span, "illegal wildcard unpack")))
-                        }
+
+                        let ty = self.tcx.bound(field.ty.clone(), field.span);
+
+                        let field_value = match value.as_const_value() {
+                            Some(const_value) => hir::Node::Const(hir::Const {
+                                value: const_value.as_struct().unwrap().get(&field.name).unwrap().value.clone(),
+                                ty,
+                                span: field.span,
+                            }),
+                            None => hir::Node::MemberAccess(hir::MemberAccess {
+                                value: Box::new(value.clone()),
+                                member_name: field.name,
+                                member_index: index as _,
+                                ty,
+                                span: field.span,
+                            }),
+                        };
+
+                        let (_, bound_node) = self.bind_name(
+                            env,
+                            field.name,
+                            visibility,
+                            ty,
+                            Some(field_value),
+                            false,
+                            kind,
+                            wildcard.span,
+                            flags - BindingInfoFlags::IS_USER_DEFINED,
+                        )?;
+
+                        statements.push(bound_node);
                     }
                 }
-            }
-        }
 
-        Ok(())
+                Ok(())
+            }
+            _ => Err(Diagnostic::error()
+                .with_message(format!("cannot use tuple unpack on type `{}`", ty.display(&self.tcx)))
+                .with_label(Label::primary(unpack_pattern.span, "illegal tuple unpack"))),
+        }
     }
 
     fn bind_tuple_unpack_pattern(

--- a/src/check/top_level.rs
+++ b/src/check/top_level.rs
@@ -9,7 +9,7 @@ use crate::{
         DiagnosticResult,
     },
     hir,
-    infer::substitute::substitute,
+    infer::substitute::substitute_node,
     span::Span,
     types::{Type, TypeId},
     workspace::{library::LIB_NAME_STD, BindingId, BindingInfoFlags, BindingInfoKind, ModuleId},
@@ -28,7 +28,7 @@ impl CheckTopLevel for ast::Binding {
     fn check_top_level(&self, sess: &mut CheckSess) -> DiagnosticResult<UstrMap<BindingId>> {
         let node = sess.with_env(self.module_id, |sess, mut env| self.check(sess, &mut env, None))?;
 
-        if let Err(mut diagnostics) = substitute(&node, &mut sess.tcx) {
+        if let Err(mut diagnostics) = substitute_node(&node, &mut sess.tcx) {
             let last = diagnostics.pop().unwrap();
             sess.workspace.diagnostics.extend(diagnostics);
             return Err(last);

--- a/src/infer/display.rs
+++ b/src/infer/display.rs
@@ -44,7 +44,7 @@ fn display_type(ty: &Type, tcx: &TypeCtx) -> String {
         Type::Array(inner, size) => format!("[{}]{}", size, display_type(inner, tcx)),
         Type::Slice(inner) => format!("[]{}", display_type(inner, tcx)),
         Type::Str(_) => "str".to_string(),
-        Type::Tuple(tys) | Type::Infer(_, InferType::PartialTuple(tys)) => format!(
+        Type::Tuple(tys) => format!(
             "({})",
             tys.iter()
                 .map(|t| display_type(t, tcx))

--- a/src/infer/display.rs
+++ b/src/infer/display.rs
@@ -55,7 +55,6 @@ fn display_type(ty: &Type, tcx: &TypeCtx) -> String {
         Type::Type(_) | Type::AnyType => "type".to_string(),
         Type::Module(_) => "{module}".to_string(),
         Type::Never => "never".to_string(),
-        Type::Infer(_, InferType::PartialStruct(ty)) => ty.display(tcx),
         Type::Infer(_, InferType::AnyInt) => "{integer}".to_string(),
         Type::Infer(_, InferType::AnyFloat) => "{float}".to_string(),
         Type::Var(_) => "?".to_string(),
@@ -81,18 +80,6 @@ impl DisplayType for StructType {
                     .join(", ")
             )
         }
-    }
-}
-
-impl DisplayType for PartialStructType {
-    fn display(&self, tcx: &TypeCtx) -> String {
-        format!(
-            "struct {{ {} }}",
-            self.iter()
-                .map(|(symbol, ty)| format!("{}: {}", symbol, display_type(ty, tcx)))
-                .collect::<Vec<String>>()
-                .join(", ")
-        )
     }
 }
 

--- a/src/infer/inference_value.rs
+++ b/src/infer/inference_value.rs
@@ -6,7 +6,6 @@ pub enum InferenceValue {
     Bound(Type),
     AnyInt,
     AnyFloat,
-    PartialTuple(Vec<Type>),
     PartialStruct(PartialStructType),
     Unbound,
 }
@@ -17,7 +16,6 @@ impl DisplayType for InferenceValue {
             InferenceValue::Bound(t) => t.display(tcx),
             InferenceValue::AnyInt => "[integer]".to_string(),
             InferenceValue::AnyFloat => "[float]".to_string(),
-            InferenceValue::PartialTuple(elements) => Type::Tuple(elements.clone()).display(tcx),
             InferenceValue::PartialStruct(partial) => partial.display(tcx),
             InferenceValue::Unbound => "unbound".to_string(),
         }

--- a/src/infer/inference_value.rs
+++ b/src/infer/inference_value.rs
@@ -1,12 +1,11 @@
 use super::display::DisplayType;
-use crate::types::{PartialStructType, Type};
+use crate::types::Type;
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum InferenceValue {
     Bound(Type),
     AnyInt,
     AnyFloat,
-    PartialStruct(PartialStructType),
     Unbound,
 }
 
@@ -16,7 +15,6 @@ impl DisplayType for InferenceValue {
             InferenceValue::Bound(t) => t.display(tcx),
             InferenceValue::AnyInt => "[integer]".to_string(),
             InferenceValue::AnyFloat => "[float]".to_string(),
-            InferenceValue::PartialStruct(partial) => partial.display(tcx),
             InferenceValue::Unbound => "unbound".to_string(),
         }
     }

--- a/src/infer/normalize.rs
+++ b/src/infer/normalize.rs
@@ -62,18 +62,6 @@ impl NormalizeCtx {
             InferenceValue::Bound(kind) => self.normalize_kind(tcx, kind),
             InferenceValue::AnyInt => self.normalize_anyint(ty),
             InferenceValue::AnyFloat => self.normalize_anyfloat(ty),
-            InferenceValue::PartialTuple(elements) => {
-                let elements = elements
-                    .iter()
-                    .map(|el| self.normalize_kind(tcx, el))
-                    .collect::<Vec<Type>>();
-
-                if self.concrete {
-                    Type::Tuple(elements)
-                } else {
-                    Type::Infer(ty, InferType::PartialTuple(elements))
-                }
-            }
             InferenceValue::PartialStruct(st) => {
                 if self.concrete {
                     Type::Struct(StructType {
@@ -161,21 +149,6 @@ impl NormalizeCtx {
             Type::Type(inner) => self.normalize_kind(tcx, inner).create_type(),
             Type::Infer(ty, InferType::AnyInt) => self.normalize_anyint(*ty),
             Type::Infer(ty, InferType::AnyFloat) => self.normalize_anyfloat(*ty),
-            Type::Infer(ty, InferType::PartialTuple(elements)) => {
-                let elements = elements
-                    .iter()
-                    .map(|el| self.normalize_kind(tcx, el))
-                    .collect::<Vec<Type>>();
-
-                if self.concrete {
-                    Type::Tuple(elements)
-                } else {
-                    Type::Infer(
-                        *ty,
-                        InferType::PartialTuple(elements.iter().map(|ty| self.normalize_kind(tcx, ty)).collect()),
-                    )
-                }
-            }
             Type::Infer(ty, InferType::PartialStruct(st)) => {
                 if self.concrete {
                     Type::Struct(StructType {

--- a/src/infer/substitute.rs
+++ b/src/infer/substitute.rs
@@ -364,9 +364,6 @@ fn extract_free_type_vars(ty: &Type, free_types: &mut HashSet<TypeId>) {
         Type::Struct(StructType { fields, .. }) => {
             fields.iter().for_each(|f| extract_free_type_vars(&f.ty, free_types));
         }
-        Type::Infer(_, InferType::PartialStruct(fields)) => {
-            fields.iter().for_each(|(_, ty)| extract_free_type_vars(ty, free_types));
-        }
 
         Type::Never
         | Type::Unit

--- a/src/infer/substitute.rs
+++ b/src/infer/substitute.rs
@@ -360,9 +360,7 @@ fn extract_free_type_vars(ty: &Type, free_types: &mut HashSet<TypeId>) {
         Type::Pointer(ty, _) | Type::Array(ty, _) | Type::Slice(ty) | Type::Str(ty) | Type::Type(ty) => {
             extract_free_type_vars(ty, free_types)
         }
-        Type::Tuple(tys) | Type::Infer(_, InferType::PartialTuple(tys)) => {
-            tys.iter().for_each(|t| extract_free_type_vars(t, free_types))
-        }
+        Type::Tuple(tys) => tys.iter().for_each(|t| extract_free_type_vars(t, free_types)),
         Type::Struct(StructType { fields, .. }) => {
             fields.iter().for_each(|f| extract_free_type_vars(&f.ty, free_types));
         }

--- a/src/infer/type_ctx.rs
+++ b/src/infer/type_ctx.rs
@@ -1,4 +1,8 @@
-use super::{display::DisplayType, inference_value::InferenceValue, normalize::Normalize};
+use super::{
+    display::DisplayType,
+    inference_value::InferenceValue,
+    normalize::{Concrete, Normalize},
+};
 use crate::{
     common::id_cache::IdCache,
     span::Span,
@@ -44,11 +48,6 @@ impl TypeCtx {
     #[inline]
     pub fn anyfloat(&mut self, span: Span) -> TypeId {
         self.insert(InferenceValue::AnyFloat, Some(span))
-    }
-
-    #[inline]
-    pub fn partial_tuple(&mut self, elements: Vec<Type>, span: Span) -> TypeId {
-        self.insert(InferenceValue::PartialTuple(elements), Some(span))
     }
 
     #[inline]
@@ -102,6 +101,19 @@ impl TypeCtx {
             .bindings
             .get_mut(id)
             .unwrap_or_else(|| panic!("type id not found: {:?}", id)) = value;
+    }
+
+    #[allow(unused)]
+    pub fn try_make_concrete(&mut self, ty: &Type) -> bool {
+        match ty {
+            Type::Infer(id, _) => {
+                let concrete = ty.concrete(self);
+                self.bind_ty(*id, concrete.clone());
+                true
+            }
+            Type::Var(_) => false,
+            _ => true,
+        }
     }
 
     #[allow(unused)]

--- a/src/infer/type_ctx.rs
+++ b/src/infer/type_ctx.rs
@@ -6,7 +6,7 @@ use super::{
 use crate::{
     common::id_cache::IdCache,
     span::Span,
-    types::{PartialStructType, Type, TypeId},
+    types::{Type, TypeId},
 };
 
 pub struct TypeCtx {
@@ -48,11 +48,6 @@ impl TypeCtx {
     #[inline]
     pub fn anyfloat(&mut self, span: Span) -> TypeId {
         self.insert(InferenceValue::AnyFloat, Some(span))
-    }
-
-    #[inline]
-    pub fn partial_struct(&mut self, partial_struct: PartialStructType, span: Span) -> TypeId {
-        self.insert(InferenceValue::PartialStruct(partial_struct), Some(span))
     }
 
     #[inline]

--- a/src/infer/unify.rs
+++ b/src/infer/unify.rs
@@ -1,11 +1,9 @@
 use super::{display::DisplayType, inference_value::InferenceValue, normalize::Normalize, type_ctx::TypeCtx};
 use crate::{
-    common::builtin::{BUILTIN_FIELD_DATA, BUILTIN_FIELD_LEN},
     error::diagnostic::{Diagnostic, Label},
     span::Span,
     types::*,
 };
-use ustr::ustr;
 
 pub trait UnifyType<T>
 where
@@ -177,74 +175,6 @@ fn unify_var_ty(var: TypeId, other: &Type, tcx: &mut TypeCtx) -> UnifyTypeResult
                 _ => Err(UnifyTypeErr::Mismatch),
             }
         }
-        InferenceValue::PartialStruct(mut partial_struct) => {
-            let other_kind = other.normalize(tcx);
-            match other_kind.maybe_deref_once() {
-                Type::Array(..) if partial_struct.contains_key(&ustr(BUILTIN_FIELD_LEN)) => {
-                    tcx.bind_ty(var, other_kind);
-                    Ok(())
-                }
-                Type::Slice(_) | Type::Str(_)
-                    if partial_struct.contains_key(&ustr(BUILTIN_FIELD_LEN))
-                        || partial_struct.contains_key(&ustr(BUILTIN_FIELD_DATA)) =>
-                {
-                    tcx.bind_ty(var, other_kind);
-                    Ok(())
-                }
-                Type::Struct(ref other_struct) => {
-                    for (name, ty) in partial_struct.iter() {
-                        // if both the partial struct and the struct have this field, unify their types
-                        if let Some(other_ty) = other_struct.field(*name) {
-                            ty.unify(&other_ty.ty, tcx)?;
-                        } else {
-                            // any field that exists in the partial struct, but doesn't exist in struct, is an error
-                            return Err(UnifyTypeErr::Mismatch);
-                        }
-                    }
-
-                    tcx.bind_ty(var, other_kind);
-
-                    Ok(())
-                }
-                Type::Module(module_id) => {
-                    // TODO: check that the names in this PartialStruct actually exist in this module
-                    tcx.bind_ty(var, Type::Module(module_id));
-                    Ok(())
-                }
-                Type::Infer(other, InferType::PartialStruct(ref other_partial)) => {
-                    for (name, ty) in partial_struct.iter() {
-                        // if both partial structs have this field, unify their types
-                        if let Some(other_ty) = other_partial.get(name) {
-                            ty.unify(other_ty, tcx)?;
-                        }
-                    }
-
-                    for (name, ty) in other_partial.iter() {
-                        // if the other partial struct has fields that this struct doesn't, add them
-                        if !partial_struct.contains_key(name) {
-                            partial_struct.insert(*name, ty.clone());
-                        }
-                    }
-
-                    // bind both vars to the new partial struct
-                    let value = InferenceValue::PartialStruct(partial_struct);
-
-                    tcx.bind_value(var, value.clone());
-                    tcx.bind_value(other, value);
-
-                    Ok(())
-                }
-                Type::Var(other) => {
-                    if other != var {
-                        tcx.bind_ty(other, var.into());
-                    }
-
-                    Ok(())
-                }
-                Type::Never => Ok(()),
-                _ => Err(UnifyTypeErr::Mismatch),
-            }
-        }
         InferenceValue::Unbound => {
             let other_kind = other.normalize(tcx);
 
@@ -264,7 +194,6 @@ pub fn occurs(var: TypeId, kind: &Type, tcx: &TypeCtx) -> bool {
             use InferenceValue::*;
             match tcx.value_of(other) {
                 Bound(ty) => occurs(var, ty, tcx) || var == other,
-                PartialStruct(partial) => partial.values().any(|ty| occurs(var, ty, tcx)) || var == other,
                 AnyInt | AnyFloat | Unbound => var == other,
             }
         }
@@ -272,9 +201,6 @@ pub fn occurs(var: TypeId, kind: &Type, tcx: &TypeCtx) -> bool {
         Type::Array(ty, _) => occurs(var, ty, tcx),
         Type::Tuple(tys) => tys.iter().any(|ty| occurs(var, ty, tcx)),
         Type::Struct(st) => st.fields.iter().any(|f| occurs(var, &f.ty, tcx)),
-        Type::Infer(other, InferType::PartialStruct(partial)) => {
-            partial.values().any(|ty| occurs(var, ty, tcx)) || var == *other
-        }
         _ => false,
     }
 }

--- a/src/interp/ffi.rs
+++ b/src/interp/ffi.rs
@@ -335,7 +335,6 @@ impl AsFfiType for Type {
                         FfiType::f32()
                     }
                 }
-                InferType::PartialStruct(_) => todo!(),
             },
             Type::Never => FfiType::void(),
             _ => panic!("invalid type {:?}", self),

--- a/src/interp/ffi.rs
+++ b/src/interp/ffi.rs
@@ -336,7 +336,6 @@ impl AsFfiType for Type {
                     }
                 }
                 InferType::PartialStruct(_) => todo!(),
-                InferType::PartialTuple(_) => todo!(),
             },
             Type::Never => FfiType::void(),
             _ => panic!("invalid type {:?}", self),

--- a/src/types/align_of.rs
+++ b/src/types/align_of.rs
@@ -20,14 +20,6 @@ impl AlignOf for Type {
             )
             .align_of(word_size),
             Type::Struct(s) => s.align_of(word_size),
-            Type::Infer(_, InferType::PartialStruct(partial_struct)) => {
-                let mut max_align: usize = 1;
-                for (_, field) in partial_struct.iter() {
-                    let field_align = field.align_of(word_size);
-                    max_align = max_align.max(field_align);
-                }
-                max_align
-            }
             Type::Infer(_, InferType::AnyInt) => IntType::Int.align_of(word_size),
             Type::Infer(_, InferType::AnyFloat) => FloatType::Float.align_of(word_size),
             _ => panic!("type {:?} is unsized", self),

--- a/src/types/align_of.rs
+++ b/src/types/align_of.rs
@@ -14,7 +14,7 @@ impl AlignOf for Type {
             Type::Float(ty) => ty.align_of(word_size),
             Type::Pointer(..) | Type::Function(..) => word_size,
             Type::Array(ty, ..) => ty.align_of(word_size),
-            Type::Infer(_, InferType::PartialTuple(elems)) | Type::Tuple(elems) => StructType::temp(
+            Type::Tuple(elems) => StructType::temp(
                 elems.iter().map(|t| StructTypeField::temp(t.clone())).collect(),
                 StructTypeKind::Struct,
             )

--- a/src/types/is_sized.rs
+++ b/src/types/is_sized.rs
@@ -25,7 +25,7 @@ impl IsSized for Type {
 
             Type::Module(_) | Type::Type(_) | Type::AnyType | Type::Var(_) | Type::Slice(_) | Type::Str(_) => false,
 
-            Type::Infer(_, InferType::PartialTuple(elems)) | Type::Tuple(elems) => elems.iter().all(|e| e.is_sized()),
+            Type::Tuple(elems) => elems.iter().all(|e| e.is_sized()),
 
             Type::Struct(s) => s.fields.iter().all(|f| f.ty.is_sized()),
 

--- a/src/types/is_sized.rs
+++ b/src/types/is_sized.rs
@@ -28,8 +28,6 @@ impl IsSized for Type {
             Type::Tuple(elems) => elems.iter().all(|e| e.is_sized()),
 
             Type::Struct(s) => s.fields.iter().all(|f| f.ty.is_sized()),
-
-            Type::Infer(_, InferType::PartialStruct(s)) => s.iter().all(|(_, ty)| ty.is_sized()),
         }
     }
 }

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -54,7 +54,6 @@ pub enum InferType {
     AnyInt,
     AnyFloat,
     PartialStruct(PartialStructType),
-    PartialTuple(Vec<Type>),
 }
 
 #[derive(Debug, PartialEq, Clone, Copy)]

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -9,8 +9,6 @@ use crate::{
     span::Span,
     workspace::{BindingId, ModuleId},
 };
-use indexmap::IndexMap;
-use std::ops::{Deref, DerefMut};
 use ustr::{ustr, Ustr};
 
 define_id_type!(TypeId);
@@ -53,7 +51,6 @@ pub enum Type {
 pub enum InferType {
     AnyInt,
     AnyFloat,
-    PartialStruct(PartialStructType),
 }
 
 #[derive(Debug, PartialEq, Clone, Copy)]
@@ -166,42 +163,6 @@ impl StructType {
     pub fn field_and_position(&self, name: impl AsRef<str>) -> Option<(usize, &StructTypeField)> {
         let field = name.as_ref();
         self.fields.iter().enumerate().find(|(_, f)| f.name == field)
-    }
-}
-
-#[derive(Debug, PartialEq, Clone)]
-pub struct PartialStructType(pub IndexMap<Ustr, Type>);
-
-impl Deref for PartialStructType {
-    type Target = IndexMap<Ustr, Type>;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl DerefMut for PartialStructType {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
-    }
-}
-
-impl PartialStructType {
-    #[allow(unused)]
-    pub fn into_struct(&self) -> StructType {
-        StructType {
-            name: ustr(""),
-            binding_id: Default::default(),
-            fields: self
-                .iter()
-                .map(|(&name, ty)| StructTypeField {
-                    name,
-                    ty: ty.clone(),
-                    span: Span::unknown(),
-                })
-                .collect(),
-            kind: StructTypeKind::Struct,
-        }
     }
 }
 

--- a/src/types/offset_of.rs
+++ b/src/types/offset_of.rs
@@ -29,17 +29,6 @@ impl OffsetOf for Type {
             )
             .offset_of(index, word_size),
             Type::Struct(s) => s.offset_of(index, word_size),
-            Type::Infer(_, InferType::PartialStruct(partial_struct)) => {
-                let mut offset = 0;
-
-                partial_struct.iter().take(index).for_each(|(_, field)| {
-                    let align = field.align_of(word_size);
-                    offset = calculate_align_from_offset(offset, align);
-                    offset += field.size_of(word_size);
-                });
-
-                offset
-            }
             ty => panic!("{:?} isn't an aggregate type", ty),
         }
     }

--- a/src/types/offset_of.rs
+++ b/src/types/offset_of.rs
@@ -23,7 +23,7 @@ impl OffsetOf for Type {
                 1 => word_size,
                 _ => panic!("{}", index),
             },
-            Type::Infer(_, InferType::PartialTuple(elems)) | Type::Tuple(elems) => StructType::temp(
+            Type::Tuple(elems) => StructType::temp(
                 elems.iter().map(|t| StructTypeField::temp(t.clone())).collect(),
                 StructTypeKind::Struct,
             )

--- a/src/types/size_of.rs
+++ b/src/types/size_of.rs
@@ -21,7 +21,7 @@ impl SizeOf for Type {
             },
             Type::Function(..) => word_size,
             Type::Array(ty, len) => ty.size_of(word_size) * len,
-            Type::Infer(_, InferType::PartialTuple(elems)) | Type::Tuple(elems) => StructType::temp(
+            Type::Tuple(elems) => StructType::temp(
                 elems.iter().map(|t| StructTypeField::temp(t.clone())).collect(),
                 StructTypeKind::Struct,
             )

--- a/src/types/size_of.rs
+++ b/src/types/size_of.rs
@@ -27,19 +27,6 @@ impl SizeOf for Type {
             )
             .size_of(word_size),
             Type::Struct(s) => s.size_of(word_size),
-            Type::Infer(_, InferType::PartialStruct(partial_struct)) => {
-                let mut offset = 0;
-
-                for (_, field) in partial_struct.iter() {
-                    let align = field.align_of(word_size);
-                    offset = calculate_align_from_offset(offset, align);
-                    offset += field.size_of(word_size);
-                }
-
-                offset = calculate_align_from_offset(offset, self.align_of(word_size));
-
-                offset
-            }
             Type::Infer(_, InferType::AnyInt) => IntType::Int.size_of(word_size),
             Type::Infer(_, InferType::AnyFloat) => FloatType::Float.size_of(word_size),
             _ => panic!("type {:?} is unsized", self),


### PR DESCRIPTION
This PR removes special inference types used to allow partially unpacked tuples/structs.
These types really complicate the type system for little benefit, so I removed them.